### PR TITLE
Add capability for ignoring request for checking null response.

### DIFF
--- a/src/Kros.MediatR.Extensions/Kros.MediatR.Extensions.csproj
+++ b/src/Kros.MediatR.Extensions/Kros.MediatR.Extensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.2</Version>
+    <Version>1.1.0-alfa1</Version>
     <Authors>KROS a.s.</Authors>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
     <PackageProjectUrl>https://github.com/Kros-sk/Kros.AspNetCore/tree/master/src/Kros.MediatR.Extensions</PackageProjectUrl>

--- a/src/Kros.MediatR.Extensions/PostProcessors/NullCheckPostProcessor.cs
+++ b/src/Kros.MediatR.Extensions/PostProcessors/NullCheckPostProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using Kros.AspNetCore.Exceptions;
+using Kros.Utils;
 using MediatR.Pipeline;
 using System.Threading.Tasks;
 
@@ -13,10 +14,21 @@ namespace Kros.MediatR.PostProcessors
     /// <exception cref="NotFoundException">If response is <see langword="null"/>.</exception>
     public class NullCheckPostProcessor<TRequest, TResponse> : IRequestPostProcessor<TRequest, TResponse>
     {
+        private NullCheckPostProcessorOptions _options;
+
+        /// <summary>
+        /// Ctor.
+        /// </summary>
+        /// <param name="options">Configuration.</param>
+        public NullCheckPostProcessor(NullCheckPostProcessorOptions options)
+        {
+            _options = Check.NotNull(options, nameof(options));
+        }
+
         /// <inheritdoc />
         public Task Process(TRequest request, TResponse response)
         {
-            if (response is null)
+            if (_options.CanCheckResponse(request) && response is null)
             {
                 throw new NotFoundException();
             }

--- a/src/Kros.MediatR.Extensions/PostProcessors/NullCheckPostProcessorOptions.cs
+++ b/src/Kros.MediatR.Extensions/PostProcessors/NullCheckPostProcessorOptions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kros.MediatR.PostProcessors
+{
+    /// <summary>
+    /// Configuration for <see cref="NullCheckPostProcessor{TRequest, TResponse}"/>
+    /// </summary>
+    public class NullCheckPostProcessorOptions
+    {
+        private HashSet<Type> _ignoredRequests = new HashSet<Type>();
+
+        /// <summary>
+        /// Default instance.
+        /// </summary>
+        public static readonly NullCheckPostProcessorOptions Default = new NullCheckPostProcessorOptions();
+
+        /// <summary>
+        /// Do not check <see langword="null"/> response for request type <typeparamref name="TRequest"/>.
+        /// This request will be ignored for checking <see langword="null"/> response.
+        /// </summary>
+        /// <typeparam name="TRequest">Ignored request type.</typeparam>
+        public NullCheckPostProcessorOptions IgnoreRequest<TRequest>()
+        {
+            _ignoredRequests.Add(typeof(TRequest));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Determine if should check response of <paramref name="request"/> for <see langword="null"/>.
+        /// </summary>
+        /// <typeparam name="TRequest">Request type.</typeparam>
+        /// <param name="request">Request.</param>
+        /// <returns><see langword="true"/> if can check response. Otherwise <see langword="false"/>.</returns>
+        public bool CanCheckResponse<TRequest>(TRequest request) => !_ignoredRequests.Contains(request.GetType());
+    }
+}

--- a/src/Kros.MediatR.Extensions/README.md
+++ b/src/Kros.MediatR.Extensions/README.md
@@ -4,7 +4,8 @@
 
 ## NullCheckPostProcessor
 
-Registrovaním `services.AddMediatRNullCheckPostProcessor()` pridáte do MediatR pipeline-y post processor, ktorý kontroluje výsledoky všetkých requestov a ak je `null` tak vyvolá `NotFoundException`.
+Registrovaním `services.AddMediatRNullCheckPostProcessor()` pridáte do MediatR pipeline-y post processor,
+ktorý kontroluje výsledoky všetkých requestov a ak je `null` tak vyvolá `NotFoundException`.
 
 Ak potrebujete niektoré requesty vynechať z kontrolovania, môžete tak spraviť nasledovne:
 

--- a/src/Kros.MediatR.Extensions/README.md
+++ b/src/Kros.MediatR.Extensions/README.md
@@ -5,7 +5,7 @@
 ## NullCheckPostProcessor
 
 Registrovaním `services.AddMediatRNullCheckPostProcessor()` pridáte do MediatR pipeline-y post processor,
-ktorý kontroluje výsledoky všetkých requestov a ak je `null` tak vyvolá `NotFoundException`.
+ktorý kontroluje výsledky všetkých requestov a ak je `null` tak vyvolá `NotFoundException`.
 
 Ak potrebujete niektoré requesty vynechať z kontrolovania, môžete tak spraviť nasledovne:
 

--- a/src/Kros.MediatR.Extensions/README.md
+++ b/src/Kros.MediatR.Extensions/README.md
@@ -4,7 +4,17 @@
 
 ## NullCheckPostProcessor
 
-Registrovaním `services.AddMediatRNullCheckPostProcessor()` pridáte do MediatR pipeline-y post processor, ktorý kontroluje výsledok requestu a ak je `null` tak vyvolá `NotFoundException`.
+Registrovaním `services.AddMediatRNullCheckPostProcessor()` pridáte do MediatR pipeline-y post processor, ktorý kontroluje výsledoky všetkých requestov a ak je `null` tak vyvolá `NotFoundException`.
+
+Ak potrebujete niektoré requesty vynechať z kontrolovania, môžete tak spraviť nasledovne:
+
+```CSharp
+services.AddMediatRNullCheckPostProcessor((o) =>
+{
+   o.IgnoreRequest<CreateDefaultUserCommand>();
+   o.IgnoreRequest<AnotherCommand>();
+});
+```
 
 ## ControllerBaseExtensions
 

--- a/src/Kros.MediatR.Extensions/ServiceCollectionExtensions.cs
+++ b/src/Kros.MediatR.Extensions/ServiceCollectionExtensions.cs
@@ -16,13 +16,12 @@ namespace Kros.MediatR.Extensions
     {
         /// <summary>
         /// Scan for MediatR pipeline behaviors
-        /// which request implement <typeparamref name="TRequest"/> and response implement <typeparamref name="TResponse"/>.
+        /// which request implement <typeparamref name="TRequest"/>.
         /// </summary>
         /// <typeparam name="TRequest">Request type.</typeparam>
-        /// <typeparam name="TResponse">Response type.</typeparam>
         /// <param name="services">Service container.</param>
         /// <exception cref="InvalidOperationException">When number of implementation
-        /// <typeparamref name="TRequest"/> and <typeparamref name="TResponse"/> are different.</exception>
+        /// <typeparamref name="TRequest"/> and response are different.</exception>
         public static IServiceCollection AddPipelineBehaviorsForRequest<TRequest>(this IServiceCollection services)
         {
             var requestType = typeof(TRequest);
@@ -77,6 +76,26 @@ namespace Kros.MediatR.Extensions
         /// </summary>
         /// <param name="services">Service container.</param>
         public static IServiceCollection AddMediatRNullCheckPostProcessor(this IServiceCollection services)
-            => services.AddSingleton(typeof(IRequestPostProcessor<,>), typeof(NullCheckPostProcessor<,>));
+            => services.AddSingleton(NullCheckPostProcessorOptions.Default)
+            .AddSingleton(typeof(IRequestPostProcessor<,>), typeof(NullCheckPostProcessor<,>));
+
+        /// <summary>
+        /// Add <see cref="NullCheckPostProcessor{TRequest, TResponse}"/> for MediatR.
+        /// </summary>
+        /// <param name="services">Service container.</param>
+        /// <param name="optionAction">Configure which requests will be ignore.</param>
+        public static IServiceCollection AddMediatRNullCheckPostProcessor(
+            this IServiceCollection services,
+            Action<NullCheckPostProcessorOptions> optionAction)
+        {
+            var options = new NullCheckPostProcessorOptions();
+
+            optionAction(options);
+
+            services.AddSingleton(options);
+            services.AddSingleton(typeof(IRequestPostProcessor<,>), typeof(NullCheckPostProcessor<,>));
+
+            return services;
+        }
     }
 }

--- a/tests/Kros.MediatR.Extensions.Tests/ControllerBaseExtensionsShould.cs
+++ b/tests/Kros.MediatR.Extensions.Tests/ControllerBaseExtensionsShould.cs
@@ -69,6 +69,7 @@ namespace Kros.MediatR.Extensions.Tests
         {
             var service = new ServiceCollection();
             service.AddMediatR();
+            service.AddMediatRNullCheckPostProcessor();
 
             var actionContext = new ActionContext
             {

--- a/tests/Kros.MediatR.Extensions.Tests/PostProcessors/NullCheckPostProcessorShould.cs
+++ b/tests/Kros.MediatR.Extensions.Tests/PostProcessors/NullCheckPostProcessorShould.cs
@@ -1,8 +1,8 @@
 ﻿using FluentAssertions;
 using Kros.AspNetCore.Exceptions;
 using Kros.MediatR.PostProcessors;
+using MediatR;
 using System;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Kros.MediatR.Extensions.Tests.PostProcessors
@@ -12,7 +12,7 @@ namespace Kros.MediatR.Extensions.Tests.PostProcessors
         [Fact]
         public void ThrowExceptionWhenResponseIsNull()
         {
-            var postProcessor = new NullCheckPostProcessor<string, string>();
+            var postProcessor = new NullCheckPostProcessor<string, string>(NullCheckPostProcessorOptions.Default);
 
             Action action = () => postProcessor.Process("", null);
 
@@ -22,11 +22,26 @@ namespace Kros.MediatR.Extensions.Tests.PostProcessors
         [Fact]
         public void DoNotThrowExceptionWhenResponseIsNotNull()
         {
-            var postProcessor = new NullCheckPostProcessor<string, string>();
+            var postProcessor = new NullCheckPostProcessor<string, string>(NullCheckPostProcessorOptions.Default);
 
             Action action = () => postProcessor.Process("request", "response");
 
             action.Should().NotThrow<NotFoundException>();
         }
+
+        [Fact]
+        public void DoNotCheckResponseIfNullCheckIgnoreIsSet()
+        {
+            var options = new NullCheckPostProcessorOptions();
+            options.IgnoreRequest<Request>();
+
+            var postProcessor = new NullCheckPostProcessor<Request, string>(options);
+
+            Action action = () => postProcessor.Process(new Request(), null);
+
+            action.Should().NotThrow<NotFoundException>();
+        }
+
+        public class Request : IRequest<string> { }
     }
 }

--- a/tests/Kros.MediatR.Extensions.Tests/ServiceCollectionExtensionsShould.cs
+++ b/tests/Kros.MediatR.Extensions.Tests/ServiceCollectionExtensionsShould.cs
@@ -6,6 +6,8 @@ using Xunit;
 using FluentAssertions;
 using MediatR.Pipeline;
 using Kros.MediatR.PostProcessors;
+using Kros.AspNetCore.Exceptions;
+using System;
 
 namespace Kros.MediatR.Extensions.Tests
 {
@@ -163,6 +165,17 @@ namespace Kros.MediatR.Extensions.Tests
             var behavior = Provider.GetRequiredService<IRequestPostProcessor<BarRequest, BarRequest.BarResponse>>();
 
             behavior.Should().BeAssignableTo<NullCheckPostProcessor<BarRequest, BarRequest.BarResponse>>();
+        }
+
+        [Fact]
+        public void RegisterNullCheckPostProcessWithIgnoringType()
+        {
+            Services.AddMediatRNullCheckPostProcessor((o)=> o.IgnoreRequest<string>());
+            var behavior = Provider.GetRequiredService<IRequestPostProcessor<string, string>>();
+
+            Action action = () => behavior.Process("", null);
+
+            action.Should().NotThrow<NotFoundException>();
         }
 
         [Fact]


### PR DESCRIPTION
Closes #9 

Added capability for ignoring request for checking `null` response.

Sometime you need request (Query), which can return `null` and you don't want throw `NotFoundException`.

You can use new overload method `AddMediatRNullCheckPostProcessor`

```CSharp
services.AddMediatRNullCheckPostProcessor((o) =>
{
   o.IgnoreRequest<CreateDefaultUserCommand>();
   o.IgnoreRequest<AnotherCommand>();
});
```

---
First idea was add `IgnoreAttribute` something like `NullCheckIgnoreAttribute`. But with reflection we can slow all requests.
