### PR TITLE
Added application insights extensions.

### DIFF
--- a/Kros.AspNetCore.sln
+++ b/Kros.AspNetCore.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kros.AspNetCore.Tests", "te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kros.MediatR.Extensions.Tests", "tests\Kros.MediatR.Extensions.Tests\Kros.MediatR.Extensions.Tests.csproj", "{808D81B7-477D-4576-83AA-A405C63ABCA5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kros.ApplicationInsights.Extensions", "src\Kros.ApplicationInsights.Extensions\Kros.ApplicationInsights.Extensions.csproj", "{879989F6-7103-4F06-A865-E862EBC31468}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,6 +39,10 @@ Global
 		{808D81B7-477D-4576-83AA-A405C63ABCA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{808D81B7-477D-4576-83AA-A405C63ABCA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{808D81B7-477D-4576-83AA-A405C63ABCA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{879989F6-7103-4F06-A865-E862EBC31468}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{879989F6-7103-4F06-A865-E862EBC31468}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{879989F6-7103-4F06-A865-E862EBC31468}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{879989F6-7103-4F06-A865-E862EBC31468}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -46,6 +52,7 @@ Global
 		{D5FD0C86-7301-4A17-B923-86F532C84798} = {BECA5997-5362-4C3D-AEF9-C2C6E40CB616}
 		{7D3EF3F7-5A32-47E2-8688-65FE68CB24B5} = {F2FE0B51-B10D-491C-AC69-1C9D08D4514E}
 		{808D81B7-477D-4576-83AA-A405C63ABCA5} = {F2FE0B51-B10D-491C-AC69-1C9D08D4514E}
+		{879989F6-7103-4F06-A865-E862EBC31468} = {BECA5997-5362-4C3D-AEF9-C2C6E40CB616}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BF06D895-E4AC-4374-95F5-89F47567F9F6}

--- a/build.yml
+++ b/build.yml
@@ -1,6 +1,6 @@
 trigger:
   tags:
-    include: [ 'aspnetcore-v*', 'mediatr-v*' ]
+    include: [ 'aspnetcore-v*', 'mediatr-v*', 'appinsights-v*' ]
 
 pool: Default
 
@@ -18,6 +18,8 @@ variables:
     value: 'Kros.AspNetCore'
   - name: project.MediatR
     value: 'Kros.MediatR.Extensions'
+  - name: project.AppInsights
+    value: 'Kros.ApplicationInsights.Extensions'
   - name: 'project.Current'
     value: ''
   - name: 'project.TestProjectsCount'
@@ -32,12 +34,17 @@ steps:
     displayName: 'Set project: $(project.MediatR)'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/mediatr-v')
 
+  - powershell: echo '##vso[task.setvariable variable=project.Current]$(project.AppInsights)'
+    displayName: 'Set project: $(project.AppInsights)'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/appinsights-v')
+
   - script: |
       echo No project was specified.
       echo Build must be triggered with correct tag and based on the tag name, the project is selected.
       echo Available tag names and their projects:
       echo   - aspnetcore-v* - Kros.AspNetCore
       echo   - mediatr-v* - Kros.MediatR.Extensions
+      echo   - appinsights-v* - Kros.ApplicationInsights.Extensions
       exit 1
     displayName: 'Check project name'
     condition: eq(variables['project.Current'], '')

--- a/src/Kros.ApplicationInsights.Extensions/ApplicationInsightsExtension.cs
+++ b/src/Kros.ApplicationInsights.Extensions/ApplicationInsightsExtension.cs
@@ -1,0 +1,43 @@
+﻿using Kros.ApplicationInsights.Extensions.Options;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Kros.ApplicationInsights.Extensions
+{
+    public static partial class ApplicationInsightsExtension
+    {
+#pragma warning disable IDE1006 // Naming Styles
+        private const string ApplicationInsightsSectionName = "ApplicationInsights";
+#pragma warning restore IDE1006 // Naming Styles
+
+        /// <summary>
+        /// Registers application telemetry into DI container.
+        /// </summary>
+        /// <param name="services">IoC container.</param>
+        /// <param name="configuration">Configuration.</param>
+        public static IServiceCollection AddApplicationInsights(this IServiceCollection services, IConfiguration configuration)
+        {
+            ApplicationInsightsOptions options = GetApplicationInsightsOptions(configuration);
+
+            if (options != null)
+            {
+                services.AddSingleton<ITelemetryInitializer>(new CloudRoleNameInitializer(options.ServiceName));
+            }
+
+            return services;
+        }
+
+        private static ApplicationInsightsOptions GetApplicationInsightsOptions(IConfiguration configuration)
+        {
+            IConfigurationSection configurationSection = configuration.GetSection(ApplicationInsightsSectionName);
+
+            if (!configurationSection.Exists())
+            {
+                return null;
+            }
+
+            return configurationSection.Get<ApplicationInsightsOptions>();
+        }
+    }
+}

--- a/src/Kros.ApplicationInsights.Extensions/ApplicationInsightsExtension.cs
+++ b/src/Kros.ApplicationInsights.Extensions/ApplicationInsightsExtension.cs
@@ -1,9 +1,8 @@
-﻿using Kros.ApplicationInsights.Extensions.Options;
-using Microsoft.ApplicationInsights.Extensibility;
+﻿using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Options;
 
-namespace Kros.ApplicationInsights.Extensions
+namespace Microsoft.Extensions.DependencyInjection
 {
     public static partial class ApplicationInsightsExtension
     {

--- a/src/Kros.ApplicationInsights.Extensions/CloudRoleNameInitializer.cs
+++ b/src/Kros.ApplicationInsights.Extensions/CloudRoleNameInitializer.cs
@@ -2,7 +2,7 @@
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 
-namespace Kros.ApplicationInsights.Extensions
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Configuration of service name representation in Application Insights.

--- a/src/Kros.ApplicationInsights.Extensions/CloudRoleNameInitializer.cs
+++ b/src/Kros.ApplicationInsights.Extensions/CloudRoleNameInitializer.cs
@@ -1,0 +1,33 @@
+﻿using Kros.Utils;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Kros.ApplicationInsights.Extensions
+{
+    /// <summary>
+    /// Configuration of service name representation in Application Insights.
+    /// </summary>
+    /// <seealso cref="Microsoft.ApplicationInsights.Extensibility.ITelemetryInitializer" />
+    public class CloudRoleNameInitializer : ITelemetryInitializer
+    {
+        private readonly string _serviceName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CloudRoleNameInitializer"/> class.
+        /// </summary>
+        /// <param name="serviceName">Service name.</param>
+        public CloudRoleNameInitializer(string serviceName)
+        {
+            _serviceName = Check.NotNullOrWhiteSpace(serviceName, nameof(serviceName));
+        }
+
+        /// <summary>
+        /// Initializes properties of the specified <see cref="T:Microsoft.ApplicationInsights.Channel.ITelemetry" /> object.
+        /// </summary>
+        public void Initialize(ITelemetry telemetry)
+        {
+            telemetry.Context.Cloud.RoleName = _serviceName;
+            telemetry.Context.Cloud.RoleInstance = _serviceName;
+        }
+    }
+}

--- a/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
+++ b/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Authors>KROS a.s.</Authors>
+    <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
+    <PackageProjectUrl>https://github.com/Kros-sk/Kros.AspNetCore/tree/master/src/Kros.ApplicationInsigths.Extensions</PackageProjectUrl>
+    <PackageIconUrl>https://en.gravatar.com/userimage/137934964/524e95fbd8c2e8779e02819ab6902bef.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/Kros-sk/Kros.AspNetCore/tree/master/src/Kros.AspNetCore</RepositoryUrl>
+    <PackageTags>ASP.NET Core;Utils;Utility;Helpers;Extensions;</PackageTags>
+    <PackageReleaseNotes>https://github.com/Kros-sk/Kros.AspNetCore/releases</PackageReleaseNotes>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Kros.Utils" Version="1.9.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
+++ b/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>KROS a.s.</Authors>
-    <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
+    <Description>Extensions to facilitate work with Application Insights.</Description>
     <PackageProjectUrl>https://github.com/Kros-sk/Kros.AspNetCore/tree/master/src/Kros.ApplicationInsigths.Extensions</PackageProjectUrl>
     <PackageIconUrl>https://en.gravatar.com/userimage/137934964/524e95fbd8c2e8779e02819ab6902bef.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/Kros-sk/Kros.AspNetCore/tree/master/src/Kros.AspNetCore</RepositoryUrl>
-    <PackageTags>ASP.NET Core;Utils;Utility;Helpers;Extensions;</PackageTags>
+    <PackageTags>ASP.NET core;Application Insights;Extensions;</PackageTags>
     <PackageReleaseNotes>https://github.com/Kros-sk/Kros.AspNetCore/releases</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Kros.ApplicationInsights.Extensions/Options/ApplicationInsightsOptions.cs
+++ b/src/Kros.ApplicationInsights.Extensions/Options/ApplicationInsightsOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace Kros.ApplicationInsights.Extensions.Options
+﻿namespace Microsoft.Extensions.DependencyInjection.Options
 {
     /// <summary>
     /// Settings for Application insights.

--- a/src/Kros.ApplicationInsights.Extensions/Options/ApplicationInsightsOptions.cs
+++ b/src/Kros.ApplicationInsights.Extensions/Options/ApplicationInsightsOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace Kros.ApplicationInsights.Extensions.Options
+{
+    /// <summary>
+    /// Settings for Application insights.
+    /// </summary>
+    public class ApplicationInsightsOptions
+    {
+        /// <summary>
+        /// Service name, which will be display in Application map.
+        /// </summary>
+        public string ServiceName { get; set; }
+    }
+}

--- a/src/Kros.MediatR.Extensions/Kros.MediatR.Extensions.csproj
+++ b/src/Kros.MediatR.Extensions/Kros.MediatR.Extensions.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>1.1.0-alpha4</Version>
     <Authors>KROS a.s.</Authors>
-    <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
+    <Description>Extensions and helpers to facilitate work with MediatR library.</Description>
     <PackageProjectUrl>https://github.com/Kros-sk/Kros.AspNetCore/tree/master/src/Kros.MediatR.Extensions</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Kros-sk/Kros.AspNetCore/tree/master/src/Kros.MediatR.Extensions</RepositoryUrl>
     <PackageIconUrl>https://en.gravatar.com/userimage/137934964/524e95fbd8c2e8779e02819ab6902bef.png</PackageIconUrl>


### PR DESCRIPTION
Closes #13 

### This PR adds Application Insights Extensions.
You can simply add Application Insigths to your projects:

```c#
public void ConfigureServices(IServiceCollection services)
{
    services.AddApplicationInsights(Configuration);
}
```

You need to configure Application Insights in appSettings.json in your project:

```#json
"ApplicationInsights": {
    "InstrumentationKey": "00112233-1234-5678-12ab-abc123456cba",
    "ServiceName": "Service.Name"
}
```