### PR TITLE
ErrorHandlingMiddleware does not change response if it has started

### DIFF
--- a/src/Kros.AspNetCore/Properties/Resources.Designer.cs
+++ b/src/Kros.AspNetCore/Properties/Resources.Designer.cs
@@ -70,6 +70,15 @@ namespace Kros.AspNetCore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exception {0} was thrown during request pipeline. Status code of the response was changed to {1}..
+        /// </summary>
+        internal static string ErrorHandlingMiddleware_StatusCodeChange {
+            get {
+                return ResourceManager.GetString("ErrorHandlingMiddleware_StatusCodeChange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; configuration section is missing or empty..
         /// </summary>
         internal static string GatewayJwtAuthorizationMissingSection {

--- a/src/Kros.AspNetCore/Properties/Resources.resx
+++ b/src/Kros.AspNetCore/Properties/Resources.resx
@@ -120,9 +120,14 @@
   <data name="AuthorizationServiceForbiddenRequest" xml:space="preserve">
     <value>Authorization service forbidden this request.</value>
   </data>
+  <data name="ErrorHandlingMiddleware_StatusCodeChange" xml:space="preserve">
+    <value>Exception {0} was thrown during request pipeline. Status code of the response was changed to {1}.</value>
+    <comment>0 - Full type name of exception.
+1 - New status code for response (number).</comment>
+  </data>
   <data name="GatewayJwtAuthorizationMissingSection" xml:space="preserve">
     <value>'{0}' configuration section is missing or empty.</value>
-    <comment>{0} - Name of the section.</comment>
+    <comment>0 - Name of the section.</comment>
   </data>
   <data name="NotFound" xml:space="preserve">
     <value>Resource was not found.</value>


### PR DESCRIPTION
* The main change is, that this middleware does not modify response, if it already has started (was sent, at least partially, to the client). Trying to change response in this state throws `InvalidOperationException`.
* There were used two different ways to reference status codes: `HttpStatusCode` and `StatusCodes`. This is unified.
* Added tests.