### PR TITLE
Patch map

### DIFF
--- a/src/Kros.AspNetCore/JsonPatch/IJsonPatchMapper.cs
+++ b/src/Kros.AspNetCore/JsonPatch/IJsonPatchMapper.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// Get database column name.
         /// </summary>
-        /// <param name="path">JSON PATCH path.</param>
+        /// <param name="path">JSON patch path.</param>
         /// <returns>Database column.</returns>
         string GetColumnName(string path);
     }

--- a/src/Kros.AspNetCore/JsonPatch/IJsonPatchMapper.cs
+++ b/src/Kros.AspNetCore/JsonPatch/IJsonPatchMapper.cs
@@ -1,0 +1,15 @@
+﻿namespace Kros.AspNetCore.JsonPatch
+{
+    /// <summary>
+    /// Mapping JSON patch operation path to database column name.
+    /// </summary>
+    internal interface IJsonPatchMapper
+    {
+        /// <summary>
+        /// Get database column name.
+        /// </summary>
+        /// <param name="path">JSON PATCH path.</param>
+        /// <returns>Database column.</returns>
+        string GetColumnName(string path);
+    }
+}

--- a/src/Kros.AspNetCore/JsonPatch/JsonPatchDocumentExtensions.cs
+++ b/src/Kros.AspNetCore/JsonPatch/JsonPatchDocumentExtensions.cs
@@ -1,0 +1,39 @@
+﻿using Kros.Extensions;
+using Microsoft.AspNetCore.JsonPatch;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Kros.AspNetCore.JsonPatch
+{
+    /// <summary>
+    /// Extensions method for <see cref="JsonPatchDocument{TModel}"/>
+    /// </summary>
+    public static class JsonPatchDocumentExtensions
+    {
+        /// <summary>
+        /// Get columns names from JSON patch operations path.
+        /// </summary>
+        /// <typeparam name="TModel">Patch model type.</typeparam>
+        /// <param name="jsonPatch">JSON patch document.</param>
+        /// <returns>Columns names.</returns>
+        /// <remarks>
+        /// Use default configuration created by <see cref="JsonPatchMapperConfig{TSource}.NewConfig"/>.
+        /// </remarks>
+        public static IEnumerable<string> GetColumnsNames<TModel>(this JsonPatchDocument<TModel> jsonPatch) where TModel : class
+            => GetColumnsNames(jsonPatch, JsonPatchMapperConfigStore.Instance.GetConfig<TModel>());
+
+        /// <summary>
+        /// Get columns names from JSON patch operations path.
+        /// </summary>
+        /// <typeparam name="TModel">Patch model type.</typeparam>
+        /// <param name="jsonPatch">JSON patch document.</param>
+        /// <param name="patchMapperConfig">Mapping configuration.</param>
+        /// <returns>Columns names.</returns>
+        public static IEnumerable<string> GetColumnsNames<TModel>(
+            this JsonPatchDocument<TModel> jsonPatch,
+            JsonPatchMapperConfig<TModel> patchMapperConfig) where TModel : class
+            => jsonPatch.Operations
+                .Select(o => ((IJsonPatchMapper)patchMapperConfig).GetColumnName(o.path))
+                .Where(p => !p.IsNullOrEmpty());
+    }
+}

--- a/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
+++ b/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
@@ -48,19 +48,12 @@ namespace Kros.AspNetCore.JsonPatch
 
         private string GetColumnNameInternal(string path)
         {
-            string property = path.TrimStart('/');
-
             if (_pathMapping != null)
             {
-                string mappedProperty = _pathMapping(property);
-                if (mappedProperty.IsNullOrEmpty()
-                    || !property.Equals(mappedProperty, StringComparison.CurrentCultureIgnoreCase))
-                {
-                    return mappedProperty;
-                }
+                path = _pathMapping(path);
             }
 
-            return property.Replace("/", string.Empty);
+            return path?.Replace("/", string.Empty);
         }
     }
 }

--- a/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
+++ b/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
@@ -30,7 +30,7 @@ namespace Kros.AspNetCore.JsonPatch
         }
 
         /// <summary>
-        /// Defines mapping rule from JSON PATCH operation path to column name.
+        /// Defines mapping rule for JSON patch operation path to column name.
         /// </summary>
         /// <param name="pathMapping">Mapping rule function.</param>
         /// <returns>Configuration instance for next fluent configuration.</returns>

--- a/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
+++ b/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
@@ -34,10 +34,12 @@ namespace Kros.AspNetCore.JsonPatch
         /// </summary>
         /// <param name="pathMapping">Mapping rule function.</param>
         /// <returns>Configuration instance for next fluent configuration.</returns>
+        /// <remarks>
+        /// When you don't want a map path, then return <see langword="null"/> from <paramref name="pathMapping"/>.
+        /// </remarks>
         public JsonPatchMapperConfig<TSource> Map(Func<string, string> pathMapping)
         {
             _pathMapping = pathMapping;
-
             return this;
         }
 

--- a/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
+++ b/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
@@ -1,0 +1,64 @@
+﻿using Kros.Extensions;
+using System;
+using System.Collections.Concurrent;
+
+namespace Kros.AspNetCore.JsonPatch
+{
+    /// <summary>
+    ///JSON PATCH mapper configuration. Configuration for mapping <see cref="JsonPatchMapperConfig{TSource}"/>
+    ///operation paths to database columns.
+    /// </summary>
+    /// <typeparam name="TSource">Source model type.</typeparam>
+    public class JsonPatchMapperConfig<TSource> : IJsonPatchMapper where TSource : class
+    {
+        private Func<string, string> _pathMapping;
+        private ConcurrentDictionary<string, string> _mapping =
+            new ConcurrentDictionary<string, string>(StringComparer.CurrentCultureIgnoreCase);
+
+        /// <summary>
+        /// Creates new config for <typeparamref name="TSource"/> and store it for non parametric  extension
+        /// <see cref="JsonPatchDocumentExtensions.GetColumnsNames{TModel}(Microsoft.AspNetCore.JsonPatch.JsonPatchDocument{TModel})"/>.
+        /// </summary>
+        /// <returns>New configuration.</returns>
+        public static JsonPatchMapperConfig<TSource> NewConfig()
+        {
+            var config = new JsonPatchMapperConfig<TSource>();
+
+            JsonPatchMapperConfigStore.Instance.Add(config);
+
+            return config;
+        }
+
+        /// <summary>
+        /// Defines mapping rule from JSON PATCH operation path to column name.
+        /// </summary>
+        /// <param name="pathMapping">Mapping rule function.</param>
+        /// <returns>Configuration instance for next fluent configuration.</returns>
+        public JsonPatchMapperConfig<TSource> Map(Func<string, string> pathMapping)
+        {
+            _pathMapping = pathMapping;
+
+            return this;
+        }
+
+        string IJsonPatchMapper.GetColumnName(string path)
+            => _mapping.GetOrAdd(path, GetColumnNameInternal);
+
+        private string GetColumnNameInternal(string path)
+        {
+            string property = path.TrimStart('/').Replace("/", ".");
+
+            if (_pathMapping != null)
+            {
+                string mappedProperty = _pathMapping(property);
+                if (mappedProperty.IsNullOrEmpty()
+                    || !property.Equals(mappedProperty, StringComparison.CurrentCultureIgnoreCase))
+                {
+                    return mappedProperty;
+                }
+            }
+
+            return property.Replace(".", string.Empty);
+        }
+    }
+}

--- a/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
+++ b/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
@@ -48,7 +48,7 @@ namespace Kros.AspNetCore.JsonPatch
 
         private string GetColumnNameInternal(string path)
         {
-            string property = path.TrimStart('/').Replace("/", ".");
+            string property = path.TrimStart('/');
 
             if (_pathMapping != null)
             {
@@ -60,7 +60,7 @@ namespace Kros.AspNetCore.JsonPatch
                 }
             }
 
-            return property.Replace(".", string.Empty);
+            return property.Replace("/", string.Empty);
         }
     }
 }

--- a/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfigStore.cs
+++ b/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfigStore.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace Kros.AspNetCore.JsonPatch
+{
+    /// <summary>
+    /// Internal store for JSON patch mapping configuration.
+    /// </summary>
+    internal class JsonPatchMapperConfigStore
+    {
+        private ConcurrentDictionary<Type, object> _configs = new ConcurrentDictionary<Type, object>();
+        private static JsonPatchMapperConfigStore _instance;
+
+        /// <summary>
+        /// Instance.
+        /// </summary>
+        public static JsonPatchMapperConfigStore Instance => _instance ?? (_instance = new JsonPatchMapperConfigStore());
+
+        private JsonPatchMapperConfigStore()
+        {
+        }
+
+        /// <summary>
+        /// Get configuration for mapping JSON patch of <typeparamref name="TSource"/> model to database names.
+        /// </summary>
+        /// <typeparam name="TSource">Type of model.</typeparam>
+        /// <returns>Configuration for mapping JSON patch of <typeparamref name="TSource"/> model to database names.</returns>
+        public JsonPatchMapperConfig<TSource> GetConfig<TSource>() where TSource : class
+            => _configs.GetOrAdd(typeof(TSource), (t) => new JsonPatchMapperConfig<TSource>()) as JsonPatchMapperConfig<TSource>;
+
+        /// <summary>
+        /// Store configuration for mapping JSON patch of <typeparamref name="TSource"/> model to database names.
+        /// </summary>
+        /// <typeparam name="TSource">Type of model.</typeparam>
+        /// <param name="jsonPatchMapperConfig">
+        /// Configuration for mapping JSON patch of <typeparamref name="TSource"/> model to database names.
+        /// </param>
+        public void Add<TSource>(JsonPatchMapperConfig<TSource> jsonPatchMapperConfig) where TSource: class
+            => _configs.TryAdd(typeof(TSource), jsonPatchMapperConfig);
+    }
+}

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Cors" Version="2.2.0" />

--- a/src/Kros.AspNetCore/README.md
+++ b/src/Kros.AspNetCore/README.md
@@ -83,14 +83,14 @@ For example: path `/Supplier/Name` is maped to `SupplierName`.
 
 ### Custom mapping
 
-When you need define custom mapping, you can use `JsonPatchDocumentMappingConfig<TModel>` for configuration.
+When you need define custom mapping, you can use `JsonPatchDocumentMapperConfig<TModel>` for configuration.
 
 ```CSharp
 JsonPatchMapperConfig<Document>
   .NewConfig()
   .Map(src =>
   {
-      const string address = ".Address.";
+      const string address = "/Address/";
 
       var index = src.IndexOf(address);
       if (index > -1)
@@ -103,6 +103,10 @@ JsonPatchMapperConfig<Document>
 ```
 
 ```CSharp
+var jsonPatch = new JsonPatchDocument<Document>();
+jsonPatch.Replace(p => p.Supplier.Address.Country, "Slovakia");
+jsonPatch.Replace(p => p.Supplier.Address.PostCode, "0101010");
+
 var columns = jsonPatch.GetColumnsNames();
 columns.Should()
   .BeEquivalentTo("SupplierCountry", "SupplierPostCode");
@@ -115,7 +119,7 @@ JsonPatchMapperConfig<Document>
   .NewConfig()
   .Map(src =>
   {
-      if (src.Contains(".Address."))
+      if (src.Contains("/Address/"))
       {
           return null;
       }

--- a/src/Kros.AspNetCore/README.md
+++ b/src/Kros.AspNetCore/README.md
@@ -83,7 +83,7 @@ For example: path `/Supplier/Name` is maped to `SupplierName`.
 
 ### Custom mapping
 
-When you need define custom mapping, you can use `JsonPatchDocumentMappingConfig<TModel>` for configuration.
+When you need define custom mapping, you can use `JsonPatchDocumentMapperConfig<TModel>` for configuration.
 
 ```CSharp
 JsonPatchMapperConfig<Document>

--- a/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
@@ -1,0 +1,151 @@
+﻿using FluentAssertions;
+using Kros.AspNetCore.JsonPatch;
+using Microsoft.AspNetCore.JsonPatch;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Kros.AspNetCore.Tests.JsonPatch
+{
+    public class JsonPatchDocumentExtensionsShould
+    {
+        [Fact]
+        public void GetColumnsNamesForFlatModelWithoutConfiguration()
+        {
+            var jsonPatch = new JsonPatchDocument<Foo>();
+            jsonPatch.Replace(p => p.Property1, "Value");
+
+            var columns = jsonPatch.GetColumnsNames();
+            columns.Should()
+                .BeEquivalentTo("Property1");
+        }
+
+        [Fact]
+        public void GetMoreColumnsNamesForFlatModelWithoutConfiguration()
+        {
+            var jsonPatch = new JsonPatchDocument<Foo>();
+            jsonPatch.Replace(p => p.Property1, "Value");
+            jsonPatch.Replace(p => p.Property2, "Value");
+
+            var columns = jsonPatch.GetColumnsNames();
+            columns.Should()
+                .BeEquivalentTo("Property1", "Property2");
+        }
+
+        [Fact]
+        public void GetColumnsNamesForComplexTypeWithFlattening()
+        {
+            var jsonPatch = new JsonPatchDocument<Document>();
+
+            jsonPatch.Replace(p => p.Supplier.Name, "Bob");
+
+            var columns = jsonPatch.GetColumnsNames(new JsonPatchMapperConfig<Document>());
+            columns.Should()
+                .BeEquivalentTo("SupplierName");
+        }
+
+        [Fact]
+        public void GetColumnsNamesForComplexTypeWithDefaultMapping()
+        {
+            JsonPatchMapperConfig<Document>
+                .NewConfig()
+                .Map(src =>
+                {
+                    const string address = ".Address.";
+
+                    var index = src.IndexOf(address);
+                    if (index > -1)
+                    {
+                        return src.Remove(index, address.Length);
+                    }
+
+                    return src;
+                });
+
+            var jsonPatch = new JsonPatchDocument<Document>();
+            jsonPatch.Replace(p => p.Supplier.Address.Country, "Slovakia");
+            jsonPatch.Replace(p => p.Supplier.Name, "Bob");
+
+            var columns = jsonPatch.GetColumnsNames();
+            columns.Should()
+                .BeEquivalentTo("SupplierCountry", "SupplierName");
+        }
+
+        [Fact]
+        public void NoMapProperties()
+        {
+            var config = new JsonPatchMapperConfig<Document>()
+                .Map(src =>
+                {
+                    if (src.Contains(".Address."))
+                    {
+                        return null;
+                    }
+
+                    return src;
+                });
+
+            var jsonPatch = new JsonPatchDocument<Document>();
+            jsonPatch.Replace(p => p.Supplier.Address.Country, "Slovakia");
+            jsonPatch.Replace(p => p.Supplier.Name, "Bob");
+
+            var columns = jsonPatch.GetColumnsNames(config);
+            columns.Should()
+                .BeEquivalentTo("SupplierName");
+        }
+
+        [Fact]
+        public void GetColumnsNamesForComplexTypeWithCustomMapping()
+        {
+            var config = new JsonPatchMapperConfig<Document>()
+                .Map(src =>
+                {
+                    const string address = ".Address.";
+
+                    var index = src.IndexOf(address);
+                    if (index > -1)
+                    {
+                        return src.Remove(index, address.Length);
+                    }
+
+                    return src;
+                });
+
+            var jsonPatch = new JsonPatchDocument<Document>();
+            jsonPatch.Replace(p => p.Supplier.Address.Country, "Slovakia");
+
+            var columns = jsonPatch.GetColumnsNames(config);
+            columns.Should()
+                .BeEquivalentTo("SupplierCountry");
+        }
+
+        #region Nested classes
+
+        public class Document
+        {
+            public Partner Supplier { get; set; } = new Partner();
+
+            public IEnumerable<string> Items { get; set; }
+        }
+
+        public class Partner
+        {
+            public string Name { get; set; }
+
+            public Address Address { get; set; } = new Address();
+        }
+
+        public class Address
+        {
+            public string Country { get; set; }
+        }
+
+        public class Foo
+        {
+            public string Property1 { get; set; }
+
+            public string Property2 { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
@@ -35,7 +35,6 @@ namespace Kros.AspNetCore.Tests.JsonPatch
         public void GetColumnsNamesForComplexTypeWithFlattening()
         {
             var jsonPatch = new JsonPatchDocument<Document>();
-
             jsonPatch.Replace(p => p.Supplier.Name, "Bob");
 
             var columns = jsonPatch.GetColumnsNames(new JsonPatchMapperConfig<Document>());
@@ -50,7 +49,7 @@ namespace Kros.AspNetCore.Tests.JsonPatch
                 .NewConfig()
                 .Map(src =>
                 {
-                    const string address = ".Address.";
+                    const string address = "/Address/";
 
                     var index = src.IndexOf(address);
                     if (index > -1)
@@ -76,7 +75,7 @@ namespace Kros.AspNetCore.Tests.JsonPatch
             var config = new JsonPatchMapperConfig<Document>()
                 .Map(src =>
                 {
-                    if (src.Contains(".Address."))
+                    if (src.Contains("/Address/"))
                     {
                         return null;
                     }
@@ -99,7 +98,7 @@ namespace Kros.AspNetCore.Tests.JsonPatch
             var config = new JsonPatchMapperConfig<Document>()
                 .Map(src =>
                 {
-                    const string address = ".Address.";
+                    const string address = "/Address/";
 
                     var index = src.IndexOf(address);
                     if (index > -1)


### PR DESCRIPTION
This PR add support for mapping `JsonPatchDocument` operations paths to database names.

## JsonPatchDocumentExtensions


```CSharp
IEnumerable<Foo> columns = jsonPatch.GetColumnsNames();
```

### Flattening pattern

This extension use flattening pattern for mapping operation path to column name.
For example: path `/Supplier/Name` is maped to `SupplierName`.

### Custom mapping

When you need define custom mapping, you can use `JsonPatchDocumentMapperConfig<TModel>` for configuration.

```CSharp
JsonPatchMapperConfig<Document>
  .NewConfig()
  .Map(src =>
  {
      const string address = "/Address/";

      var index = src.IndexOf(address);
      if (index > -1)
      {
          return src.Remove(index, address.Length);
      }

      return src;
  });
```

```CSharp
var jsonPatch = new JsonPatchDocument<Document>();
jsonPatch.Replace(p => p.Supplier.Address.Country, "Slovakia");
jsonPatch.Replace(p => p.Supplier.Address.PostCode, "0101010");

var columns = jsonPatch.GetColumnsNames();
columns.Should()
  .BeEquivalentTo("SupplierCountry", "SupplierPostCode");
```

If you don't want map a path, then return `null` from mapping function.

```CSharp
JsonPatchMapperConfig<Document>
  .NewConfig()
  .Map(src =>
  {
      if (src.Contains("/Address/"))
      {
          return null;
      }

      return src;
  });
```
