### PR TITLE
Patch fix

### DIFF
--- a/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
+++ b/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
@@ -1,6 +1,7 @@
 ﻿using Kros.Extensions;
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 
 namespace Kros.AspNetCore.JsonPatch
 {
@@ -53,7 +54,13 @@ namespace Kros.AspNetCore.JsonPatch
                 path = _pathMapping(path);
             }
 
-            return path?.Replace("/", string.Empty);
+            return path != null
+                ? string.Join(
+                    string.Empty,
+                    path.Split('/')
+                        .Where(p => !p.IsNullOrWhiteSpace())
+                        .Select(p => $"{char.ToUpper(p.First())}{p.Substring(1)}"))
+                : null;
         }
     }
 }

--- a/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
@@ -121,7 +121,6 @@ namespace Kros.AspNetCore.Tests.JsonPatch
         [Fact]
         public void MapPathToColumnsNamesAsPascalCase()
         {
-
             var jsonPatch = new JsonPatchDocument();
             jsonPatch.Replace("/supplier/address/country", "Slovakia");
 

--- a/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
@@ -62,7 +62,6 @@ namespace Kros.AspNetCore.Tests.JsonPatch
                 });
 
             var jsonPatch = new JsonPatchDocument<Document>();
-
             jsonPatch.Replace(p => p.Supplier.Address.Country, "Slovakia");
             jsonPatch.Replace(p => p.Supplier.Name, "Bob");
 

--- a/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kros.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.JsonPatch;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using Xunit;
 
@@ -61,6 +62,7 @@ namespace Kros.AspNetCore.Tests.JsonPatch
                 });
 
             var jsonPatch = new JsonPatchDocument<Document>();
+
             jsonPatch.Replace(p => p.Supplier.Address.Country, "Slovakia");
             jsonPatch.Replace(p => p.Supplier.Name, "Bob");
 
@@ -115,6 +117,21 @@ namespace Kros.AspNetCore.Tests.JsonPatch
             var columns = jsonPatch.GetColumnsNames(config);
             columns.Should()
                 .BeEquivalentTo("SupplierCountry");
+        }
+
+        [Fact]
+        public void MapPathToColumnsNamesAsPascalCase()
+        {
+
+            var jsonPatch = new JsonPatchDocument();
+            jsonPatch.Replace("/supplier/address/country", "Slovakia");
+
+            var serialized = JsonConvert.SerializeObject(jsonPatch);
+            var deserialized = JsonConvert.DeserializeObject<JsonPatchDocument<Document>>(serialized);
+
+            var columns = deserialized.GetColumnsNames(new JsonPatchMapperConfig<Document>());
+            columns.Should()
+                .BeEquivalentTo("SupplierAddressCountry");
         }
 
         #region Nested classes


### PR DESCRIPTION
JSON patch has operations paths as **camelCase** (thank you for the warning @vojtechrojicek).
Therefore, I need to transform columns names to **PascalCase** format.