### PR TITLE
Add caching for autorization

### DIFF
--- a/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
@@ -1,9 +1,12 @@
 ﻿using Kros.Utils;
 using Microsoft.AspNetCore.Http;
+using Microsoft.DotNet.PlatformAbstractions;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using System;
 using System.Net.Http;
+using System.Security.Policy;
 using System.Threading.Tasks;
 
 namespace Kros.AspNetCore.Authorization
@@ -39,11 +42,13 @@ namespace Kros.AspNetCore.Authorization
         /// </summary>
         /// <param name="httpContext">Http context.</param>
         /// <param name="httpClientFactory">Http client factory.</param>
+        /// <param name="memoryCache">Cache for caching authorization token.</param>
         public async Task Invoke(
             HttpContext httpContext,
-            IHttpClientFactory httpClientFactory)
+            IHttpClientFactory httpClientFactory,
+            IMemoryCache memoryCache)
         {
-            string userJwt = await GetUserAuthorizationJwtAsync(httpContext, httpClientFactory);
+            string userJwt = await GetUserAuthorizationJwtAsync(httpContext, httpClientFactory, memoryCache);
 
             if (!string.IsNullOrEmpty(userJwt))
             {
@@ -53,29 +58,65 @@ namespace Kros.AspNetCore.Authorization
             await _next(httpContext);
         }
 
-        private async Task<string> GetUserAuthorizationJwtAsync(HttpContext httpContext, IHttpClientFactory httpClientFactory)
+        private async Task<string> GetUserAuthorizationJwtAsync(
+            HttpContext httpContext,
+            IHttpClientFactory httpClientFactory,
+            IMemoryCache memoryCache)
         {
             if (httpContext.Request.Headers.TryGetValue(HeaderNames.Authorization, out StringValues value))
             {
-                using (HttpClient client = httpClientFactory.CreateClient(AuthorizationHttpClientName))
+                int key = GetKey(httpContext, value);
+
+                if (!memoryCache.TryGetValue(key, out string jwtToken))
                 {
-                    client.DefaultRequestHeaders.Add(HeaderNames.Authorization, value.ToString());
-
-                    HttpResponseMessage response = await client.GetAsync(_jwtAuthorizationOptions.AuthorizationUrl + httpContext.Request.Path.Value);
-
-                    if (response.IsSuccessStatusCode)
-                    {
-                        return await response.Content.ReadAsStringAsync();
-                    }
-                    else
-                    {
-                        throw new UnauthorizedAccessException(Properties.Resources.AuthorizationServiceForbiddenRequest);
-                    }
+                    jwtToken = await GetUserAuthorizationJwtAsync(httpContext, httpClientFactory, memoryCache, value, key);
                 }
+
+                return jwtToken;
             }
 
             return string.Empty;
         }
+
+        private async Task<string> GetUserAuthorizationJwtAsync(HttpContext httpContext,
+            IHttpClientFactory httpClientFactory,
+            IMemoryCache memoryCache,
+            StringValues value,
+            int key)
+        {
+            using (HttpClient client = httpClientFactory.CreateClient(AuthorizationHttpClientName))
+            {
+                client.DefaultRequestHeaders.Add(HeaderNames.Authorization, value.ToString());
+
+                HttpResponseMessage response = await client.GetAsync(_jwtAuthorizationOptions.AuthorizationUrl + httpContext.Request.Path.Value);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    string jwtToken = await response.Content.ReadAsStringAsync();
+                    SetTokenToCache(memoryCache, key, jwtToken);
+
+                    return jwtToken;
+                }
+                else
+                {
+                    throw new UnauthorizedAccessException(Properties.Resources.AuthorizationServiceForbiddenRequest);
+                }
+            }
+        }
+
+        private void SetTokenToCache(IMemoryCache memoryCache, int key, string jwtToken)
+        {
+            if (_jwtAuthorizationOptions.CacheSlidingExpirationOffset != TimeSpan.Zero)
+            {
+                var cacheEntryOptions = new MemoryCacheEntryOptions()
+                        .SetSlidingExpiration(_jwtAuthorizationOptions.CacheSlidingExpirationOffset);
+
+                memoryCache.Set(key, jwtToken, cacheEntryOptions);
+            }
+        }
+
+        private static int GetKey(HttpContext httpContext, StringValues value)
+            => HashCode.Combine(value, httpContext.Request.Path);
 
         private void AddUserProfileClaimsToIdentityAndHttpHeaders(HttpContext httpContext, string userJwtToken)
         {

--- a/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
@@ -78,7 +78,8 @@ namespace Kros.AspNetCore.Authorization
             return string.Empty;
         }
 
-        private async Task<string> GetUserAuthorizationJwtAsync(HttpContext httpContext,
+        private async Task<string> GetUserAuthorizationJwtAsync(
+            HttpContext httpContext,
             IHttpClientFactory httpClientFactory,
             IMemoryCache memoryCache,
             StringValues value,

--- a/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Kros.AspNetCore.Authorization
+﻿using System;
+
+namespace Kros.AspNetCore.Authorization
 {
     /// <summary>
     /// JWT authorization options for api gateway.
@@ -9,5 +11,13 @@
         /// Authorization service url.
         /// </summary>
         public string AuthorizationUrl { get; set; }
+
+        /// <summary>
+        /// Cache sliding expiration offset.
+        /// </summary>
+        /// <remarks>
+        /// Default is <see cref="TimeSpan.Zero"/>.
+        /// </remarks>
+        public TimeSpan CacheSlidingExpirationOffset { get; set; } = TimeSpan.Zero;
     }
 }

--- a/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
+++ b/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
@@ -17,7 +17,9 @@ namespace Kros.AspNetCore.Authorization
         /// </summary>
         /// <param name="services">Collection of app services.</param>
         public static IServiceCollection AddGatewayJwtAuthorization(this IServiceCollection services)
-            => services.AddHttpClient(GatewayAuthorizationMiddleware.AuthorizationHttpClientName)
+            => services
+            .AddMemoryCache()
+            .AddHttpClient(GatewayAuthorizationMiddleware.AuthorizationHttpClientName)
             .Services;
 
         /// <summary>

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <Version>1.2.0</Version>
     <Authors>KROS a.s.</Authors>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>

--- a/src/Kros.MediatR.Extensions/Kros.MediatR.Extensions.csproj
+++ b/src/Kros.MediatR.Extensions/Kros.MediatR.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <Version>1.1.0-alpha4</Version>
     <Authors>KROS a.s.</Authors>
     <Description>Extensions and helpers to facilitate work with MediatR library.</Description>

--- a/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
@@ -119,7 +119,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             {
                 AuthorizationUrl = "http://authorizationservice.com",
                 CacheSlidingExpirationOffset = offset
-            }); ;
+            });
 
             return (httpClientFactory, middleware);
         }

--- a/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
@@ -1,6 +1,8 @@
 ﻿using FluentAssertions;
 using Kros.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using NSubstitute;
 using System;
@@ -20,7 +22,7 @@ namespace Kros.AspNetCore.Tests.Authorization
 
             var context = new DefaultHttpContext();
             context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
-            await middleware.Invoke(context, httpClientFactoryMock);
+            await middleware.Invoke(context, httpClientFactoryMock, new MemoryCache(new MemoryCacheOptions()));
 
             context.Request.Headers[HeaderNames.Authorization]
                 .Should()
@@ -30,12 +32,50 @@ namespace Kros.AspNetCore.Tests.Authorization
         }
 
         [Fact]
+        public async void UseCachedJwtToken()
+        {
+            (var httpClientFactoryMock, var middleware) = CreateMiddleware(HttpStatusCode.OK);
+            string accessToken = "access_token";
+
+            var context = new DefaultHttpContext();
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            cache.Set(HashCode.Combine(accessToken, context.Request.Path), "AAAAAA");
+
+            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            await middleware.Invoke(context, httpClientFactoryMock, cache);
+
+            context.Request.Headers[HeaderNames.Authorization]
+                .Should()
+                .HaveCount(1)
+                .And
+                .Contain("Bearer AAAAAA");
+        }
+
+        [Fact]
+        public async void CachedJwtToken()
+        {
+            (var httpClientFactoryMock, var middleware) = CreateMiddleware(HttpStatusCode.OK, TimeSpan.FromSeconds(5));
+            string accessToken = "access_token";
+
+            var context = new DefaultHttpContext();
+            var cache = new MemoryCache(new MemoryCacheOptions());
+
+            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            await middleware.Invoke(context, httpClientFactoryMock, cache);
+
+            var aaa = cache.Get(HashCode.Combine(accessToken, context.Request.Path));
+            cache.Get(HashCode.Combine(accessToken, context.Request.Path))
+                .Should()
+                .Be("MyJwtToken");
+        }
+
+        [Fact]
         public async void DoNotAddJwtTokenIntoHeaderWhenAuthorizationHeaderIsMissing()
         {
             (var httpClientFactoryMock, var middleware) = CreateMiddleware(HttpStatusCode.OK);
 
             var context = new DefaultHttpContext();
-            await middleware.Invoke(context, httpClientFactoryMock);
+            await middleware.Invoke(context, httpClientFactoryMock, new MemoryCache(new MemoryCacheOptions()));
 
             context.Request.Headers[HeaderNames.Authorization]
                 .Should().BeEmpty();
@@ -52,10 +92,15 @@ namespace Kros.AspNetCore.Tests.Authorization
             context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
 
             Assert.ThrowsAsync<UnauthorizedAccessException>(async ()
-                => await middleware.Invoke(context, httpClientFactoryMock));
+                => await middleware.Invoke(context, httpClientFactoryMock, new MemoryCache(new MemoryCacheOptions())));
         }
 
         private static (IHttpClientFactory, GatewayAuthorizationMiddleware) CreateMiddleware(HttpStatusCode statusCode)
+            => CreateMiddleware(statusCode, TimeSpan.Zero);
+
+        private static (IHttpClientFactory, GatewayAuthorizationMiddleware) CreateMiddleware(
+            HttpStatusCode statusCode,
+            TimeSpan offset)
         {
             var httpClientFactory = Substitute.For<IHttpClientFactory>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(new HttpResponseMessage()
@@ -70,7 +115,11 @@ namespace Kros.AspNetCore.Tests.Authorization
             var middleware = new GatewayAuthorizationMiddleware((c) =>
             {
                 return Task.CompletedTask;
-            }, new GatewayJwtAuthorizationOptions() { AuthorizationUrl = "http://authorizationservice.com" });
+            }, new GatewayJwtAuthorizationOptions()
+            {
+                AuthorizationUrl = "http://authorizationservice.com",
+                CacheSlidingExpirationOffset = offset
+            }); ;
 
             return (httpClientFactory, middleware);
         }

--- a/tests/Kros.AspNetCore.Tests/Kros.AspNetCore.Tests.csproj
+++ b/tests/Kros.AspNetCore.Tests/Kros.AspNetCore.Tests.csproj
@@ -16,6 +16,9 @@
     <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.6.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add caching for authorization.

Now we can set caching for authorization info in apigateway. For this, you can set property `CacheSlidingExpirationOffset` in `application.json` to your timespan offset.

```Json
"GatewayJwtAuthorization": {
    "AuthorizationUrl": "url",
    "CacheSlidingExpirationOffset": "00:00:10"
 }
```