### PR TITLE
Added ability to define paths that do not use caching for authorization.

### DIFF
--- a/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
@@ -93,7 +93,7 @@ namespace Kros.AspNetCore.Authorization
                 if (response.IsSuccessStatusCode)
                 {
                     string jwtToken = await response.Content.ReadAsStringAsync();
-                    SetTokenToCache(memoryCache, key, jwtToken);
+                    SetTokenToCache(memoryCache, key, jwtToken, httpContext.Request);
 
                     return jwtToken;
                 }
@@ -121,9 +121,11 @@ namespace Kros.AspNetCore.Authorization
             }
         }
 
-        private void SetTokenToCache(IMemoryCache memoryCache, int key, string jwtToken)
+        private void SetTokenToCache(IMemoryCache memoryCache, int key, string jwtToken, HttpRequest request)
         {
-            if (_jwtAuthorizationOptions.CacheSlidingExpirationOffset != TimeSpan.Zero)
+            if (_jwtAuthorizationOptions.CacheSlidingExpirationOffset != TimeSpan.Zero &&
+               !(request.Method == HttpMethod.Get.ToString() &&
+                 _jwtAuthorizationOptions.IgnoredPathForCache.Contains(request.Path.Value.ToLower().TrimEnd('/'))))
             {
                 var cacheEntryOptions = new MemoryCacheEntryOptions()
                         .SetSlidingExpiration(_jwtAuthorizationOptions.CacheSlidingExpirationOffset);

--- a/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -125,7 +126,7 @@ namespace Kros.AspNetCore.Authorization
         {
             if (_jwtAuthorizationOptions.CacheSlidingExpirationOffset != TimeSpan.Zero &&
                !(request.Method == HttpMethod.Get.ToString() &&
-                 _jwtAuthorizationOptions.IgnoredPathForCache.Contains(request.Path.Value.ToLower().TrimEnd('/'))))
+                 _jwtAuthorizationOptions.IgnoredPathForCache.Contains(request.Path.Value.TrimEnd('/'), StringComparer.OrdinalIgnoreCase)))
             {
                 var cacheEntryOptions = new MemoryCacheEntryOptions()
                         .SetSlidingExpiration(_jwtAuthorizationOptions.CacheSlidingExpirationOffset);

--- a/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Kros.AspNetCore.Authorization
 {
@@ -19,5 +20,10 @@ namespace Kros.AspNetCore.Authorization
         /// Default is <see cref="TimeSpan.Zero"/>.
         /// </remarks>
         public TimeSpan CacheSlidingExpirationOffset { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
+        /// Roads that do not use JWT authorization caching 
+        /// </summary>
+        public List<string> IgnoredPathForCache { get; private set; } = new List<string>();
     }
 }

--- a/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
@@ -74,7 +74,7 @@ namespace Kros.AspNetCore.Tests.Authorization
         public async void JwtTokenWithoutCaching()
         {
             var ignoredPath = new List<string>();
-            ignoredPath.Add("/ignoredpath");
+            ignoredPath.Add("/IgnoredPath");
             (var httpClientFactoryMock, var middleware) = CreateMiddleware(HttpStatusCode.OK, TimeSpan.FromSeconds(5), ignoredPath);
             string accessToken = "access_token";
 
@@ -183,10 +183,7 @@ namespace Kros.AspNetCore.Tests.Authorization
                 CacheSlidingExpirationOffset = offset
             };
             gatewayJwtAuthorizationOptions.IgnoredPathForCache.AddRange(ignoredPathForCache);
-            var middleware = new GatewayAuthorizationMiddleware((c) =>
-            {
-                return Task.CompletedTask;
-            }, gatewayJwtAuthorizationOptions);
+            var middleware = new GatewayAuthorizationMiddleware((c) => Task.CompletedTask, gatewayJwtAuthorizationOptions);
 
             return (httpClientFactory, middleware);
         }

--- a/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Net.Http.Headers;
 using NSubstitute;
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -67,6 +68,28 @@ namespace Kros.AspNetCore.Tests.Authorization
             cache.Get(HashCode.Combine(accessToken, context.Request.Path))
                 .Should()
                 .Be("MyJwtToken");
+        }
+
+        [Fact]
+        public async void JwtTokenWithoutCaching()
+        {
+            var ignoredPath = new List<string>();
+            ignoredPath.Add("/ignoredpath");
+            (var httpClientFactoryMock, var middleware) = CreateMiddleware(HttpStatusCode.OK, TimeSpan.FromSeconds(5), ignoredPath);
+            string accessToken = "access_token";
+
+            var context = new DefaultHttpContext();
+            var cache = new MemoryCache(new MemoryCacheOptions());
+
+            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            context.Request.Path = "/ignoredPath/";
+            context.Request.Method = HttpMethod.Get.ToString();
+            await middleware.Invoke(context, httpClientFactoryMock, cache);
+
+            var aaa = cache.Get(HashCode.Combine(accessToken, context.Request.Path));
+            cache.Get(HashCode.Combine(accessToken, context.Request.Path))
+                .Should()
+                .BeNull();
         }
 
         [Fact]
@@ -132,11 +155,17 @@ namespace Kros.AspNetCore.Tests.Authorization
         }
 
         private static (IHttpClientFactory, GatewayAuthorizationMiddleware) CreateMiddleware(HttpStatusCode statusCode)
-            => CreateMiddleware(statusCode, TimeSpan.Zero);
+            => CreateMiddleware(statusCode, TimeSpan.Zero, new List<string>());
+
+        private static (IHttpClientFactory, GatewayAuthorizationMiddleware) CreateMiddleware(
+           HttpStatusCode statusCode,
+           TimeSpan offset)
+            => CreateMiddleware(statusCode, offset, new List<string>());
 
         private static (IHttpClientFactory, GatewayAuthorizationMiddleware) CreateMiddleware(
             HttpStatusCode statusCode,
-            TimeSpan offset)
+            TimeSpan offset,
+            List<string> ignoredPathForCache)
         {
             var httpClientFactory = Substitute.For<IHttpClientFactory>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(new HttpResponseMessage()
@@ -148,14 +177,16 @@ namespace Kros.AspNetCore.Tests.Authorization
 
             httpClientFactory.CreateClient("JwtAuthorizationClientName").Returns(fakeHttpClient);
 
-            var middleware = new GatewayAuthorizationMiddleware((c) =>
-            {
-                return Task.CompletedTask;
-            }, new GatewayJwtAuthorizationOptions()
+            var gatewayJwtAuthorizationOptions = new GatewayJwtAuthorizationOptions()
             {
                 AuthorizationUrl = "http://authorizationservice.com",
                 CacheSlidingExpirationOffset = offset
-            });
+            };
+            gatewayJwtAuthorizationOptions.IgnoredPathForCache.AddRange(ignoredPathForCache);
+            var middleware = new GatewayAuthorizationMiddleware((c) =>
+            {
+                return Task.CompletedTask;
+            }, gatewayJwtAuthorizationOptions);
 
             return (httpClientFactory, middleware);
         }


### PR DESCRIPTION
Now we can set path that do not use caching for authorization info in apigateway. For this, you can set property IgnoredPathForCache in application.json.
 
```Json
"GatewayJwtAuthorization": {
    "AuthorizationUrl": "url",
    "CacheSlidingExpirationOffset": "00:00:10",
    "IgnoredPathForCache":  [ "/ignoredpath" ]
}
```