### PR TITLE
Strong typed validating configuration

### DIFF
--- a/src/Kros.AspNetCore/BaseStartup.cs
+++ b/src/Kros.AspNetCore/BaseStartup.cs
@@ -1,5 +1,5 @@
-﻿using Kros.AspNetCore.Extensions;
-using Kros.AspNetCore.Options;
+﻿using Kros.AspNetCore.Configuration;
+using Kros.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -18,7 +18,7 @@ namespace Kros.AspNetCore
         /// Ctor.
         /// </summary>
         /// <param name="env">Information about the web hosting environment.</param>
-        public BaseStartup(IWebHostEnvironment env)
+        protected BaseStartup(IWebHostEnvironment env)
         {
             IConfigurationBuilder builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)

--- a/src/Kros.AspNetCore/Configuration/AnnotatedSettingsBase.cs
+++ b/src/Kros.AspNetCore/Configuration/AnnotatedSettingsBase.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Kros.AspNetCore.Configuration
+{
+    /// <summary>
+    /// Base class for settings, where properties can be annotated using data annotations attributes and
+    /// and the state of the object is validated against them.
+    /// </summary>
+    public abstract class AnnotatedSettingsBase : IValidatable
+    {
+        /// <summary>
+        /// Validates the object using data annotations validator (<see cref="Validator"/>).
+        /// </summary>
+        public virtual void Validate()
+            => Validator.ValidateObject(this, new ValidationContext(this), validateAllProperties: true);
+    }
+}

--- a/src/Kros.AspNetCore/Configuration/AnnotatedSettingsBase.cs
+++ b/src/Kros.AspNetCore/Configuration/AnnotatedSettingsBase.cs
@@ -3,7 +3,7 @@
 namespace Kros.AspNetCore.Configuration
 {
     /// <summary>
-    /// Base class for settings, where properties can be annotated using data annotations attributes and
+    /// Base class for settings, where properties can be annotated using data annotations attributes
     /// and the state of the object is validated against them.
     /// </summary>
     public abstract class AnnotatedSettingsBase : IValidatable

--- a/src/Kros.AspNetCore/Configuration/CorsOptions.cs
+++ b/src/Kros.AspNetCore/Configuration/CorsOptions.cs
@@ -1,0 +1,18 @@
+﻿namespace Kros.AspNetCore.Configuration
+{
+    /// <summary>
+    /// Cors options.
+    /// </summary>
+    public static class CorsOptions
+    {
+        /// <summary>
+        /// Name of cors section in appsettings.json.
+        /// </summary>
+        public const string CorsSectionName = "AllowedHosts";
+
+        /// <summary>
+        /// Name of custom cors policy.
+        /// </summary>
+        public const string CorsPolicyName = "CustomCorsPolicy";
+    }
+}

--- a/src/Kros.AspNetCore/Configuration/IValidatable.cs
+++ b/src/Kros.AspNetCore/Configuration/IValidatable.cs
@@ -1,0 +1,13 @@
+﻿namespace Kros.AspNetCore.Configuration
+{
+    /// <summary>
+    /// Interface for objects that can validate their state.
+    /// </summary>
+    public interface IValidatable
+    {
+        /// <summary>
+        /// Validates the object. If the object state is not valid, method must throw exception (any exception is OK).
+        /// </summary>
+        void Validate();
+    }
+}

--- a/src/Kros.AspNetCore/Configuration/SettingsValidationException.cs
+++ b/src/Kros.AspNetCore/Configuration/SettingsValidationException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Kros.AspNetCore.Configuration
+{
+    /// <summary>
+    /// Standard exception for settings validation: <see cref="IValidatable"/>.
+    /// </summary>
+    public class SettingsValidationException : Exception
+    {
+        /// <summary>
+        /// Create a new instance of <see cref="SettingsValidationException"/>
+        /// </summary>
+        /// <param name="message">Exception message.</param>
+        public SettingsValidationException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="SettingsValidationException"/>
+        /// </summary>
+        /// <param name="message">Exception message.</param>
+        /// <param name="innerException">Inner exception.</param>
+        public SettingsValidationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Kros.AspNetCore/Configuration/SettingsValidationStartupFilter.cs
+++ b/src/Kros.AspNetCore/Configuration/SettingsValidationStartupFilter.cs
@@ -1,0 +1,39 @@
+﻿using Kros.Utils;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Kros.AspNetCore.Configuration
+{
+    /// <summary>
+    /// An <see cref="IStartupFilter"/> that validates all <see cref="IValidatable"/> objects in DI container during
+    /// application startup.
+    /// Turn on validation by using <see cref="ServiceCollectionExtensions.UseConfigurationValidation(IServiceCollection)"/>
+    /// extension method in your <c>ConfigureServices</c> method.
+    /// </summary>
+    public class SettingsValidationStartupFilter : IStartupFilter
+    {
+        private readonly IEnumerable<IValidatable> _validatableObjects;
+
+        /// <summary>
+        /// Create a new instance of <see cref="SettingsValidationStartupFilter"/>
+        /// </summary>
+        /// <param name="validatableObjects"></param>
+        public SettingsValidationStartupFilter(IEnumerable<IValidatable> validatableObjects)
+        {
+            _validatableObjects = Check.NotNull(validatableObjects, nameof(validatableObjects));
+        }
+
+        /// <inheritdoc />
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            foreach (IValidatable validatableObject in _validatableObjects)
+            {
+                validatableObject.Validate();
+            }
+            return next;
+        }
+    }
+}

--- a/src/Kros.AspNetCore/Configuration/SettingsValidationStartupFilter.cs
+++ b/src/Kros.AspNetCore/Configuration/SettingsValidationStartupFilter.cs
@@ -20,7 +20,7 @@ namespace Kros.AspNetCore.Configuration
         /// <summary>
         /// Create a new instance of <see cref="SettingsValidationStartupFilter"/>
         /// </summary>
-        /// <param name="validatableObjects"></param>
+        /// <param name="validatableObjects">List of objects to validate.</param>
         public SettingsValidationStartupFilter(IEnumerable<IValidatable> validatableObjects)
         {
             _validatableObjects = Check.NotNull(validatableObjects, nameof(validatableObjects));

--- a/src/Kros.AspNetCore/Extensions/ConfigurationExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Kros.AspNetCore;
-using Kros.AspNetCore.Options;
-using System;
+using Kros.AspNetCore.Configuration;
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Kros.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
 ﻿using Kros.AspNetCore;
+using Kros.AspNetCore.Configuration;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using System;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -10,6 +13,13 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class ServiceCollectionExtensions
     {
         /// <summary>
+        /// Add an <see cref="IStartupFilter"/> to the application that invokes <see cref="IValidatable.Validate"/>
+        /// on all registered objects.
+        /// </summary>
+        public static IServiceCollection UseConfigurationValidation(this IServiceCollection services)
+            => services.AddTransient<IStartupFilter, SettingsValidationStartupFilter>();
+
+        /// <summary>
         /// Configure options of type <typeparamref name="TOptions"/> and binds it to section with the name
         /// same as the class <typeparamref name="TOptions"/> without Options suffix in <paramref name="configuration"/>.
         /// </summary>
@@ -19,7 +29,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>Returns input <paramref name="services"/>.</returns>
         public static IServiceCollection ConfigureOptions<TOptions>(
             this IServiceCollection services,
-            IConfiguration configuration) where TOptions : class
+            IConfiguration configuration) where TOptions : class, new()
             => ConfigureOptions<TOptions>(services, configuration, Helpers.GetSectionName<TOptions>());
 
         /// <summary>
@@ -34,8 +44,16 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection ConfigureOptions<TOptions>(
             this IServiceCollection services,
             IConfiguration configuration,
-            string sectionName) where TOptions : class
-            => services.Configure<TOptions>(options => configuration.GetSection(sectionName).Bind(options));
+            string sectionName) where TOptions : class, new()
+        {
+            services.Configure<TOptions>(options => configuration.GetSection(sectionName).Bind(options));
+            services.AddSingleton<TOptions>(ctx => ctx.GetRequiredService<IOptions<TOptions>>().Value);
+            if (typeof(IValidatable).IsAssignableFrom(typeof(TOptions)))
+            {
+                services.AddSingleton<IValidatable>(ctx => (IValidatable)ctx.GetRequiredService<IOptions<TOptions>>().Value);
+            }
+            return services;
+        }
 
         /// <summary>
         /// Adds the minimum essential MVC services to the DI container for web API services.

--- a/src/Kros.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Extensions.DependencyInjection
             string sectionName) where TOptions : class, new()
         {
             services.Configure<TOptions>(options => configuration.GetSection(sectionName).Bind(options));
-            services.AddSingleton<TOptions>(ctx => ctx.GetRequiredService<IOptions<TOptions>>().Value);
+            services.AddTransient<TOptions>(ctx => ctx.GetRequiredService<IOptionsSnapshot<TOptions>>().Value);
             if (typeof(IValidatable).IsAssignableFrom(typeof(TOptions)))
             {
                 services.AddSingleton<IValidatable>(ctx => (IValidatable)ctx.GetRequiredService<IOptions<TOptions>>().Value);

--- a/src/Kros.AspNetCore/Helpers.cs
+++ b/src/Kros.AspNetCore/Helpers.cs
@@ -1,4 +1,6 @@
-﻿namespace Kros.AspNetCore
+﻿using System;
+
+namespace Kros.AspNetCore
 {
     /// <summary>
     /// General helpers.
@@ -6,22 +8,28 @@
     public static class Helpers
     {
         /// <summary>
-        /// Get section name by <typeparamref name="TOptions"/> type.
-        /// Section name is class name without <c>Options</c> suffix, so if class name is <c>SmtpOptions</c>, the section
-        /// name is <c>Smtp</c>.
+        /// Get section name by <typeparamref name="TOptions"/> type. Section name is class name without <c>Options</c>
+        /// or <c>Settings</c> suffix. So if class name is <c>SmtpOptions</c>, the name is <c>Smtp</c>.
         /// </summary>
         /// <typeparam name="TOptions">Option type.</typeparam>
         /// <returns>Class name without Options suffix.</returns>
         public static string GetSectionName<TOptions>() where TOptions : class
+            => GetSectionName(typeof(TOptions));
+
+        internal static string GetSectionName(Type optionsType)
         {
-            const string uselessSuffix = "Options";
-            string sectionName = typeof(TOptions).Name;
+            const string uselessSuffixOptions = "Options";
+            const string uselessSuffixSettings = "Settings";
+            string sectionName = optionsType.Name;
 
-            if (sectionName.EndsWith(uselessSuffix))
+            if (sectionName.EndsWith(uselessSuffixOptions, StringComparison.OrdinalIgnoreCase))
             {
-                return sectionName.Substring(0, sectionName.Length - uselessSuffix.Length);
+                return sectionName.Substring(0, sectionName.Length - uselessSuffixOptions.Length);
             }
-
+            else if (sectionName.EndsWith(uselessSuffixSettings, StringComparison.OrdinalIgnoreCase))
+            {
+                return sectionName.Substring(0, sectionName.Length - uselessSuffixSettings.Length);
+            }
             return sectionName;
         }
     }

--- a/src/Kros.AspNetCore/Options/CorsOptions.cs
+++ b/src/Kros.AspNetCore/Options/CorsOptions.cs
@@ -1,18 +1,21 @@
-﻿namespace Kros.AspNetCore.Options
+﻿using System;
+
+namespace Kros.AspNetCore.Options
 {
     /// <summary>
     /// Cors options.
     /// </summary>
+    [Obsolete("Class was moved to Kros.AspNetCore.Configuration namespace.")]
     public class CorsOptions
     {
         /// <summary>
         /// Name of cors section in appsettings.json.
         /// </summary>
-        public const string CorsSectionName = "AllowedHosts";
+        public const string CorsSectionName = Kros.AspNetCore.Configuration.CorsOptions.CorsSectionName;
 
         /// <summary>
         /// Name of custom cors policy.
         /// </summary>
-        public const string CorsPolicyName = "CustomCorsPolicy";
+        public const string CorsPolicyName = Kros.AspNetCore.Configuration.CorsOptions.CorsPolicyName;
     }
 }

--- a/src/Kros.AspNetCore/README.md
+++ b/src/Kros.AspNetCore/README.md
@@ -33,11 +33,12 @@ V adresári `Extensions` sa nachádzajú rôzne rozšírenia štandardných trie
 Na jednoduchú konfiguráciu slúži extension metóda `ConfigureOptions<TOptions>(Configuration)`. Táto metóda triedu `TOptions`
 napojí na nastavenia (konfigurácia napríklad v `appsettings.json`) podľa názvu triedy a triedu zaregistruje do DI kontajnera ako:
 
-- `IOptions<TOptions>`
-- Singleton `TOptions`
+- `IOptions<TOptions>`, `IOptionsSnapshot<TOptions>` (štandardná registrácia metódou `Configure`)
+- `TOptions`
 
 Keďže je trieda zaregistrovaná aj priamo, v iných triedach je možné ju priamo používať ako závislosť (tzn. nie je potrebné
-používať komplikovanejšiu závislosť na `IOptions<TOptions>`).
+používať komplikovanejšiu závislosť na `IOptions<TOptions>`). Trieda je registrovaná ako `Transient` a podporuje _hot reload_.
+Takže ak sa zmenia nastavenia, ďalšia inštancia `TOptions` vypýtaná z DI kontajnera bude mať nové nastavenia.
 
 Nastavenia v konfigurácii sa hľadajú podľa názvu triedy, pričom ak trieda má koncovku `Options`, alebo `Settings`, táto
 koncovka ignoruje. Tzn. trieda `SmtpSettings` alebo `SmtpOptions` je nastavená podľa sekcie s názvom `Smtp`.

--- a/src/Kros.AspNetCore/README.md
+++ b/src/Kros.AspNetCore/README.md
@@ -43,8 +43,8 @@ Nastavenia v konfigurácii sa hľadajú podľa názvu triedy, pričom ak trieda 
 koncovka ignoruje. Tzn. trieda `SmtpSettings` alebo `SmtpOptions` je nastavená podľa sekcie s názvom `Smtp`.
 
 Konfiguráciu je možné validovať implementovaním rozhrania `IValidatable` v triede nastavení. Rozhranie má jedinú metódu
-`Validate()`, ktorá vykonáva validáciu. V prípade chyby validácis vyvolá ľubovoľnú výnimku, pričom preferovaná je výnimka
-`SettingsValidationException`. Pre jednoduchšiu implementáciu nastavení ktoré sa validujú je vytvorená zíkladná trieda
+`Validate()`, ktorá vykonáva validáciu. V prípade chyby validácia vyvolá ľubovoľnú výnimku, pričom preferovaná je výnimka
+`SettingsValidationException`. Pre jednoduchšiu implementáciu nastavení ktoré sa validujú je vytvorená základná trieda
 `AnnotatedSettingsBase`, ktorá implementuje validáciu pomocou *data annotations* atribútov. Takže samotnú validáciu nie je
 potrebné implementovať, akurát príslušnými atribútmi odekorovať potrebné vlastnosti. _(Ak validácia zlyhá, nie je vyvolaná
 výnimka `SettingsValidationException`, ale `ValidationException` z data annotácií.)_
@@ -56,7 +56,7 @@ aplikácie zmysel.
 
 #### Príklad
 
-``` c#
+``` csharp
 public class SmtpSettings : AnnotatedSettingsBase
 {
     // This value is required, so it must be set in configuration file.
@@ -92,7 +92,7 @@ public class SmtpEmailSender
 
 ### DistributedCacheExtensions
 
-Jednoduchšie vkládanie/získavanie komplexných typov z/do distribuovanej keše.
+Jednoduchšie vkladanie/získavanie komplexných typov z/do distribuovanej keše.
 
 Taktiež umožňuje získať hodnotu z keše a keď tam nieje tak ju vytvoriť a do keše vložiť.
 

--- a/tests/Kros.AspNetCore.Tests/Configuration/ConfigurationExtensionsTests.cs
+++ b/tests/Kros.AspNetCore.Tests/Configuration/ConfigurationExtensionsTests.cs
@@ -1,0 +1,72 @@
+﻿using FluentAssertions;
+using Kros.AspNetCore.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Kros.AspNetCore.Tests.Configuration
+{
+    public class ConfigurationExtensionsTests
+    {
+        const string TestSettingsJson = @"
+{
+  ""Test"": {
+    ""StringValue"": ""Lorem Ipsum"",
+    ""IntValue"": 42
+  }
+}";
+
+        class TestSettings
+        {
+            public string StringValue { get; set; }
+            public int IntValue { get; set; }
+        }
+
+        class ValidatableTestSettings : IValidatable
+        {
+            public string StringValue { get; set; }
+            public int IntValue { get; set; }
+
+            public void Validate()
+            {
+            }
+        }
+
+        [Fact]
+        public void ConfigureOptionsRegistersClassIntoDiContainer()
+        {
+            IConfiguration cfg = new ConfigurationBuilder()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(TestSettingsJson)))
+                .Build();
+            var services = new ServiceCollection();
+
+            services.ConfigureOptions<TestSettings>(cfg);
+
+            ServiceProvider provider = services.BuildServiceProvider();
+            TestSettings settings = provider.GetRequiredService<TestSettings>();
+
+            settings.Should().NotBeNull();
+            settings.Should().BeEquivalentTo(new TestSettings
+            {
+                StringValue = "Lorem Ipsum",
+                IntValue = 42
+            });
+        }
+
+        [Fact]
+        public void ConfigureOptionsRegistersClassAsIValidatableIntoDiContainer()
+        {
+            IConfiguration cfg = new ConfigurationBuilder().Build();
+            var services = new ServiceCollection();
+            services.ConfigureOptions<ValidatableTestSettings>(cfg);
+            ServiceProvider provider = services.BuildServiceProvider();
+
+            IValidatable settings = provider.GetRequiredService<IValidatable>();
+
+            settings.Should().NotBeNull();
+            settings.Should().BeOfType<ValidatableTestSettings>();
+        }
+    }
+}

--- a/tests/Kros.AspNetCore.Tests/Configuration/DataAnnotatedSettingsTests.cs
+++ b/tests/Kros.AspNetCore.Tests/Configuration/DataAnnotatedSettingsTests.cs
@@ -1,0 +1,52 @@
+﻿using FluentAssertions;
+using Kros.AspNetCore.Configuration;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Xunit;
+
+namespace Kros.AspNetCore.Tests.Configuration
+{
+    public class DataAnnotatedSettingsTests
+    {
+        public class TestSettings : AnnotatedSettingsBase
+        {
+            [Required]
+            public string Text { get; set; }
+
+            public string NotValidated { get; set; }
+        }
+
+        public class NotAnnotatedTestSettings : AnnotatedSettingsBase
+        {
+            public string Text { get; set; }
+
+            public string NotValidated { get; set; }
+        }
+
+        [Fact]
+        public void ValidateMustThrowIfSettingsAreIncorrect()
+        {
+            var settings = new TestSettings();
+
+            Action action = () => settings.Validate();
+
+            action.Should().Throw<ValidationException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidateMustNotThrowIfSettingsAreCorrect_Data))]
+        public void ValidateMustNotThrowIfSettingsAreCorrect(IValidatable settings)
+        {
+            Action action = () => settings.Validate();
+
+            action.Should().NotThrow();
+        }
+
+        public static IEnumerable<object[]> ValidateMustNotThrowIfSettingsAreCorrect_Data()
+        {
+            yield return new object[] { new TestSettings { Text = "Lorem Ipsum" } };
+            yield return new object[] { new NotAnnotatedTestSettings() };
+        }
+    }
+}

--- a/tests/Kros.AspNetCore.Tests/HelpersShould.cs
+++ b/tests/Kros.AspNetCore.Tests/HelpersShould.cs
@@ -1,4 +1,6 @@
 ﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Kros.AspNetCore.Tests
@@ -8,27 +10,38 @@ namespace Kros.AspNetCore.Tests
         #region Test classes
 
         class TestOptions
-        {}
+        { }
+
+        class Test2options
+        { }
+
+        class TestSettings
+        { }
+
+        class Test2settings
+        { }
 
         class TestClass
         { }
 
         #endregion
 
-        [Fact]
-        public void GetSectionName()
+        [Theory]
+        [MemberData(nameof(GetSectionName_TestData))]
+        public void GetSectionName(Type tOptions, string expectedSectionName)
         {
-            Helpers.GetSectionName<TestOptions>()
+            Helpers.GetSectionName(tOptions)
                 .Should()
-                .Be("Test");
+                .Be(expectedSectionName);
         }
 
-        [Fact]
-        public void GetSectionNameWhenDoNotEndWithOptions()
+        public static IEnumerable<object[]> GetSectionName_TestData()
         {
-            Helpers.GetSectionName<TestClass>()
-                .Should()
-                .Be("TestClass");
+            yield return new object[] { typeof(TestOptions), "Test" };
+            yield return new object[] { typeof(Test2options), "Test2" };
+            yield return new object[] { typeof(TestSettings), "Test" };
+            yield return new object[] { typeof(Test2settings), "Test2" };
+            yield return new object[] { typeof(TestClass), "TestClass" };
         }
     }
 }


### PR DESCRIPTION
More info is in [README in Configuration section](https://github.com/satano/Kros.AspNetCore/tree/StrongTypedOptions/src/Kros.AspNetCore#Configuration).

Inspired by [Adding validation to strongly typed configuration objects in ASP.NET Core](https://andrewlock.net/adding-validation-to-strongly-typed-configuration-objects-in-asp-net-core/).

**Other changes:**

- `Helpers.GetSectionName` now ignores not only `Options` suffix, but also `Settings`, and is case insensitive.
- `CorsOptions` class is moved from `Options` namespace to `Configuration`.