### PR TITLE
added JsonPatchException to ErrorHandlingMiddleware

### DIFF
--- a/src/Kros.AspNetCore/Middlewares/ErrorHandlingMiddleware.cs
+++ b/src/Kros.AspNetCore/Middlewares/ErrorHandlingMiddleware.cs
@@ -3,6 +3,7 @@ using Kros.AspNetCore.Extensions;
 using Kros.AspNetCore.Properties;
 using Kros.Utils;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.JsonPatch.Exceptions;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
@@ -37,6 +38,10 @@ namespace Kros.AspNetCore.Middlewares
             try
             {
                 await _next.Invoke(context);
+            }
+            catch (JsonPatchException ex)
+            {
+                SetResponseType(context, ex, StatusCodes.Status400BadRequest);
             }
             catch (BadRequestException ex)
             {

--- a/tests/Kros.AspNetCore.Tests/ErrorHandling/ErrorHandlingMiddlewareShould.cs
+++ b/tests/Kros.AspNetCore.Tests/ErrorHandling/ErrorHandlingMiddlewareShould.cs
@@ -2,6 +2,7 @@
 using Kros.AspNetCore.Exceptions;
 using Kros.AspNetCore.Middlewares;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.JsonPatch.Exceptions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using System;
@@ -15,6 +16,7 @@ namespace Kros.AspNetCore.Tests.ErrorHandling
     {
         private static readonly (Exception ex, int statusCode)[] _knownExceptions = new (Exception, int)[]
         {
+            (new JsonPatchException(), StatusCodes.Status400BadRequest),
             (new BadRequestException(), StatusCodes.Status400BadRequest),
             (new UnauthorizedAccessException(), StatusCodes.Status401Unauthorized),
             (new ResourceIsForbiddenException(), StatusCodes.Status403Forbidden),


### PR DESCRIPTION
added JsonPatchException to ErrorHandlingMiddleware to handle exception thrown on bad input for enum value.
