### PR TITLE
Update Mass Transit

### DIFF
--- a/src/Kros.MassTransit.AzureServiceBus/Endpoints/Endpoint.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/Endpoints/Endpoint.cs
@@ -54,7 +54,6 @@ namespace Kros.MassTransit.AzureServiceBus.Endpoints
         /// Sets endpoint and its consumers during service bus initialization.
         /// </summary>
         /// <param name="busCfg">Service bus configuration.</param>
-        /// <param name="host">Service bus host.</param>
-        public abstract void SetEndpoint(IServiceBusBusFactoryConfigurator busCfg, IServiceBusHost host);
+        public abstract void SetEndpoint(IServiceBusBusFactoryConfigurator busCfg);
     }
 }

--- a/src/Kros.MassTransit.AzureServiceBus/Endpoints/ReceiveEndpoint.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/Endpoints/ReceiveEndpoint.cs
@@ -41,8 +41,8 @@ namespace Kros.MassTransit.AzureServiceBus.Endpoints
             => _consumers.Add(endpointConfig => endpointConfig.Consumer(provider, configure));
 
         /// <inheritdoc />
-        public override void SetEndpoint(IServiceBusBusFactoryConfigurator busCfg, IServiceBusHost host)
-            => busCfg.ReceiveEndpoint(host, Name, endpointConfig =>
+        public override void SetEndpoint(IServiceBusBusFactoryConfigurator busCfg)
+            => busCfg.ReceiveEndpoint(Name, endpointConfig =>
             {
                 _configurator?.Invoke(endpointConfig);
 

--- a/src/Kros.MassTransit.AzureServiceBus/Endpoints/SubscriptionEndpoint.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/Endpoints/SubscriptionEndpoint.cs
@@ -41,8 +41,8 @@ namespace Kros.MassTransit.AzureServiceBus.Endpoints
             => _consumers.Add(endpointConfig => endpointConfig.Consumer(provider, configure));
 
         /// <inheritdoc />
-        public override void SetEndpoint(IServiceBusBusFactoryConfigurator busCfg, IServiceBusHost host)
-            => busCfg.SubscriptionEndpoint<TMessage>(host, Name, endpointConfig =>
+        public override void SetEndpoint(IServiceBusBusFactoryConfigurator busCfg)
+            => busCfg.SubscriptionEndpoint<TMessage>(Name, endpointConfig =>
             {
                 _configurator?.Invoke(endpointConfig);
 

--- a/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
+++ b/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <Version>1.0.0-alpha.2</Version>
+    <Version>1.0.0-alpha.3</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>Simpler configuration of MassTransit library.</Description>
@@ -25,8 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="Kros.Utils" Version="1.10.1" />
-    <PackageReference Include="MassTransit.AspNetCore" Version="5.5.6" />
-    <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="5.5.6" />
+    <PackageReference Include="MassTransit.AspNetCore" Version="6.0.0" />
+    <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="6.0.0" />
     <PackageReference Include="Scrutor" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
@@ -167,7 +167,7 @@ namespace Kros.MassTransit.AzureServiceBus
                 IServiceBusHost host = CreateServiceHost(busCfg);
 
                 ConfigureServiceBus(busCfg, host);
-                AddEndpoints(busCfg, host);
+                AddEndpoints(busCfg);
 
                 if (_provider != null)
                 {
@@ -220,12 +220,11 @@ namespace Kros.MassTransit.AzureServiceBus
         /// Adds endpoints to service bus.
         /// </summary>
         /// <param name="busCfg">Service bus configuration.</param>
-        /// <param name="host">Service bus host.</param>
-        private void AddEndpoints(IServiceBusBusFactoryConfigurator busCfg, IServiceBusHost host)
+        private void AddEndpoints(IServiceBusBusFactoryConfigurator busCfg)
         {
             foreach (Endpoint endpoint in _endpoints)
             {
-                endpoint.SetEndpoint(busCfg, host);
+                endpoint.SetEndpoint(busCfg);
             }
         }
 


### PR DESCRIPTION
Closes #62 

I updated MassTransit packages to the newest version and the error no longer occurs during ASP.NET Core app start. The problem could have been linked to imperfect .NET Core 3.0 support in older versions of packages.

Visual Studio informed me that after package update some code had became obsolete (IServiceBusHost is no longer needed for endpoint configuration), so I updated that code as well.
