### PR TITLE
Move add json local file into extension

### DIFF
--- a/src/Kros.AspNetCore/BaseStartup.cs
+++ b/src/Kros.AspNetCore/BaseStartup.cs
@@ -17,17 +17,11 @@ namespace Kros.AspNetCore
         /// <summary>
         /// Ctor.
         /// </summary>
+        /// <param name="configuration">Application configuration.</param>
         /// <param name="env">Information about the web hosting environment.</param>
-        protected BaseStartup(IWebHostEnvironment env)
+        protected BaseStartup(IConfiguration configuration, IWebHostEnvironment env)
         {
-            IConfigurationBuilder builder = new ConfigurationBuilder()
-                .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json")
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
-                .AddJsonFile($"appsettings.local.json", optional: true)
-                .AddEnvironmentVariables();
-
-            Configuration = builder.Build();
+            Configuration = configuration;
             Environment = env;
         }
 

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -13,6 +13,6 @@ namespace Kros.AspNetCore.Extensions
         /// <param name="configurationBuilder">Configuration builder.</param>
         /// <returns>The same instance of the Microsoft.Extensions.Hosting.IHostBuilder for chaining.</returns>
         public static IConfigurationBuilder AddLocalConfiguration(this IConfigurationBuilder configurationBuilder)
-            => configurationBuilder.AddJsonFile("appsettings.local.json", optional: true);            
+            => configurationBuilder.AddJsonFile("appsettings.local.json", optional: true);
     }
 }

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Kros.AspNetCore.Extensions
+{
+    /// <summary>
+    /// Configuration builder extenstions.
+    /// </summary>
+    public static class ConfigurationBuilderExtenstions
+    {
+        /// <summary>
+        /// Add local.json configuration.
+        /// </summary>
+        /// <param name="configurationBuilder">Configuration builder.</param>
+        /// <returns>The same instance of the Microsoft.Extensions.Hosting.IHostBuilder for chaining.</returns>
+        public static IConfigurationBuilder AddLocalConfiguration(this IConfigurationBuilder configurationBuilder)
+            => configurationBuilder.AddJsonFile("appsettings.local.json", optional: true);            
+    }
+}

--- a/src/Kros.AspNetCore/Extensions/HostBuilderExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/HostBuilderExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Kros.AspNetCore.Extensions
+{
+    /// <summary>
+    /// Host builder extensions.
+    /// </summary>
+    public static class HostBuilderExtensions
+    {
+        /// <summary>
+        /// Add local.json configuration.
+        /// </summary>
+        /// <param name="hostBuilder">Host builder.</param>
+        /// <returns>The same instance of the Microsoft.Extensions.Hosting.IHostBuilder for chaining.</returns>
+        public static IHostBuilder AddLocalConfiguration(this IHostBuilder hostBuilder)
+            => hostBuilder.ConfigureAppConfiguration((hostingContext, config) =>
+            {
+                config.SetBasePath(hostingContext.HostingEnvironment.ContentRootPath)
+                      .AddJsonFile("appsettings.local.json", optional: true);
+            });
+    }
+}

--- a/src/Kros.AspNetCore/Extensions/HostBuilderExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/HostBuilderExtensions.cs
@@ -17,7 +17,7 @@ namespace Kros.AspNetCore.Extensions
             => hostBuilder.ConfigureAppConfiguration((hostingContext, config) =>
             {
                 config.SetBasePath(hostingContext.HostingEnvironment.ContentRootPath)
-                      .AddJsonFile("appsettings.local.json", optional: true);
+                    .AddLocalConfiguration();
             });
     }
 }


### PR DESCRIPTION
Closes #66 

Move
 ```cs 
config.AddJsonFile("appsettings.local.json", optional: true);
``` 
from  `BaseStartup` to  `HostBuilderExtensions.AddLocalConfiguration` or `ConfigurationBuilderExtenstions.AddLocalConfiguration`.
If you can use appsetting.local.json file, you must add `.AddLocalConfiguration()` into `Program.CreateHostBuilder`.

For example: 
 ```cs 
public static IHostBuilder CreateHostBuilder(string[] args) =>
    Host.CreateDefaultBuilder(args)
        .AddLocalConfiguration()
        .ConfigureWebHostDefaults(webBuilder =>
        {
            webBuilder.UseStartup<Startup>();
        });
 ```

