### PR TITLE
Added hash authorization to GatewayAuthorizationMiddleware

### DIFF
--- a/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
@@ -70,7 +70,7 @@ namespace Kros.AspNetCore.Authorization
 
                 if (!memoryCache.TryGetValue(key, out string jwtToken))
                 {
-                    var authUrl = $"{_jwtAuthorizationOptions.BaseUrl}{_jwtAuthorizationOptions.AuthorizationPath}{httpContext.Request.Path.Value}";
+                    var authUrl = $"{_jwtAuthorizationOptions.AuthorizationUrl}{httpContext.Request.Path.Value}";
                     jwtToken = await GetUserAuthorizationJwtAsync(httpContext, httpClientFactory, memoryCache, value, key, authUrl);
                 }
 
@@ -79,7 +79,8 @@ namespace Kros.AspNetCore.Authorization
             else if (httpContext.Request.Query.TryGetValue(_jwtAuthorizationOptions.HashParameterName, out StringValues hashValue))
             {
                 int key = GetKey(httpContext, hashValue);
-                var authUrl = $"{_jwtAuthorizationOptions.BaseUrl}{_jwtAuthorizationOptions.HashAuthorizationPath}?{_jwtAuthorizationOptions.HashParameterName}={hashValue}";
+                var queryString = QueryString.Create(_jwtAuthorizationOptions.HashParameterName, hashValue);
+                var authUrl = $"{_jwtAuthorizationOptions.HashAuthorizationUrl}{queryString.ToUriComponent()}";
                 return await GetUserAuthorizationJwtAsync(httpContext, httpClientFactory, memoryCache, StringValues.Empty, key, authUrl);
             }
 

--- a/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
@@ -78,10 +78,15 @@ namespace Kros.AspNetCore.Authorization
             }
             else if (httpContext.Request.Query.TryGetValue(_jwtAuthorizationOptions.HashParameterName, out StringValues hashValue))
             {
-                int key = GetKey(httpContext, hashValue);
-                var queryString = QueryString.Create(_jwtAuthorizationOptions.HashParameterName, hashValue);
-                var authUrl = $"{_jwtAuthorizationOptions.HashAuthorizationUrl}{queryString.ToUriComponent()}";
-                return await GetUserAuthorizationJwtAsync(httpContext, httpClientFactory, memoryCache, StringValues.Empty, key, authUrl);
+                int key = GetKey(httpContext, hashValue.ToString());
+                if (!memoryCache.TryGetValue(key, out string jwtToken))
+                {
+                    var queryString = QueryString.Create(_jwtAuthorizationOptions.HashParameterName, hashValue.ToString());
+                    var authUrl = $"{_jwtAuthorizationOptions.HashAuthorizationUrl}{queryString.ToUriComponent()}";
+                    jwtToken = await GetUserAuthorizationJwtAsync(httpContext, httpClientFactory, memoryCache, StringValues.Empty, key, authUrl);
+                }
+
+                return jwtToken;
             }
 
             return string.Empty;

--- a/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
@@ -9,9 +9,24 @@ namespace Kros.AspNetCore.Authorization
     public class GatewayJwtAuthorizationOptions
     {
         /// <summary>
-        /// Authorization service url.
+        /// Base authorization service url.
         /// </summary>
-        public string AuthorizationUrl { get; set; }
+        public string BaseUrl { get; set; }
+
+        /// <summary>
+        /// Authorization service path.
+        /// </summary>
+        public string AuthorizationPath { get; set; }
+
+        /// <summary>
+        /// Hash authorization service path.
+        /// </summary>
+        public string HashAuthorizationPath { get; set; }
+
+        /// <summary>
+        /// Hash authorization service path.
+        /// </summary>
+        public string HashParameterName { get; set; }
 
         /// <summary>
         /// Cache sliding expiration offset.

--- a/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
@@ -9,22 +9,17 @@ namespace Kros.AspNetCore.Authorization
     public class GatewayJwtAuthorizationOptions
     {
         /// <summary>
-        /// Base authorization service url.
+        /// Authorization service url.
         /// </summary>
-        public string BaseUrl { get; set; }
+        public string AuthorizationUrl { get; set; }
 
         /// <summary>
-        /// Authorization service path.
+        /// Hash authorization url.
         /// </summary>
-        public string AuthorizationPath { get; set; }
+        public string HashAuthorizationUrl { get; set; }
 
         /// <summary>
-        /// Hash authorization service path.
-        /// </summary>
-        public string HashAuthorizationPath { get; set; }
-
-        /// <summary>
-        /// Hash authorization service path.
+        /// Hash authorization parameter name.
         /// </summary>
         public string HashParameterName { get; set; }
 


### PR DESCRIPTION
Added another option of authentication/authorization into the GatewayAuthorizationMiddleware. Instead of searching for the Authorization header in a HttpRequest, requests with the query parameter 'hash' (configurable) can also be authorized via the Authorization service. The returned jwt tokens are cached as well.

To implement, the gateway needs to suport two new settings (as seen in GatewayJwtAuthorizationOptions): 

- HashAuthorizationUrl - authorization service endpoint url for hash authentication
- HashParameterName - the hash authentication will be used if this parameter is in the request (and the Authorization header is not)

Also, the authorization service needs a new endpoint for requests with hashes.
