### PR TITLE
Fixed wrong authorization service URI

### DIFF
--- a/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
@@ -69,9 +69,8 @@ namespace Kros.AspNetCore.Authorization
 
                 if (!memoryCache.TryGetValue(key, out string jwtToken))
                 {
-                    var uriBuilder = new UriBuilder(_jwtAuthorizationOptions.AuthorizationUrl);
-                    uriBuilder.Path = httpContext.Request.Path.Value;
-                    jwtToken = await GetUserAuthorizationJwtAsync(httpContext, httpClientFactory, memoryCache, value, key, uriBuilder.Uri.ToString());
+                    var authUrl = _jwtAuthorizationOptions.AuthorizationUrl + httpContext.Request.Path.Value;
+                    jwtToken = await GetUserAuthorizationJwtAsync(httpContext, httpClientFactory, memoryCache, value, key, authUrl);
                 }
 
                 return jwtToken;

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <Version>2.4.0</Version>
+    <Version>2.4.1</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>


### PR DESCRIPTION
Fixed wrong authorization service URI, a part of path was truncated (the fix was to revert to original code).
Changed version to 2.4.1.

