### PR TITLE
Service discovery

### DIFF
--- a/src/Kros.AspNetCore/Authorization/AuthorizationServiceOptions.cs
+++ b/src/Kros.AspNetCore/Authorization/AuthorizationServiceOptions.cs
@@ -1,0 +1,18 @@
+﻿namespace Kros.AspNetCore.Authorization
+{
+    /// <summary>
+    /// Authorization service definition
+    /// </summary>
+    public class AuthorizationServiceOptions
+    {
+        /// <summary>
+        /// Authorization service name.
+        /// </summary>
+        public string ServiceName { get; set; }
+
+        /// <summary>
+        /// Path name.
+        /// </summary>
+        public string PathName { get; set; }
+    }
+}

--- a/src/Kros.AspNetCore/Authorization/AuthorizationServiceOptions.cs
+++ b/src/Kros.AspNetCore/Authorization/AuthorizationServiceOptions.cs
@@ -1,7 +1,7 @@
 ﻿namespace Kros.AspNetCore.Authorization
 {
     /// <summary>
-    /// Authorization service definition
+    /// Authorization service definition.
     /// </summary>
     public class AuthorizationServiceOptions
     {

--- a/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Kros.AspNetCore.ServiceDiscovery;
+using Kros.Extensions;
+using System;
 using System.Collections.Generic;
 
 namespace Kros.AspNetCore.Authorization
@@ -14,9 +16,28 @@ namespace Kros.AspNetCore.Authorization
         public string AuthorizationUrl { get; set; }
 
         /// <summary>
+        /// Gets or sets the authorization.
+        /// </summary>
+        public AuthorizationServiceOptions Authorization { get; set; }
+
+        internal string GetAuthorizationUrl(IServiceDiscoveryProvider provider)
+            => AuthorizationUrl ?? GetUrl(provider, HashAuthorization);
+
+        /// <summary>
         /// Hash authorization url.
         /// </summary>
         public string HashAuthorizationUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the authorization.
+        /// </summary>
+        public AuthorizationServiceOptions HashAuthorization { get; set; }
+
+        internal string GetHashAuthorization(IServiceDiscoveryProvider provider)
+            => HashAuthorizationUrl ?? GetUrl(provider, HashAuthorization);
+
+        private string GetUrl(IServiceDiscoveryProvider provider, AuthorizationServiceOptions authorization)
+            => provider.GetPath(authorization.ServiceName, authorization.PathName).ToString();
 
         /// <summary>
         /// Hash authorization parameter name.
@@ -32,7 +53,7 @@ namespace Kros.AspNetCore.Authorization
         public TimeSpan CacheSlidingExpirationOffset { get; set; } = TimeSpan.Zero;
 
         /// <summary>
-        /// Paths that do not use JWT authorization caching 
+        /// Paths that do not use JWT authorization caching
         /// </summary>
         public List<string> IgnoredPathForCache { get; private set; } = new List<string>();
     }

--- a/src/Kros.AspNetCore/Properties/Resources.Designer.cs
+++ b/src/Kros.AspNetCore/Properties/Resources.Designer.cs
@@ -124,6 +124,24 @@ namespace Kros.AspNetCore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Service &apos;{0}&apos; does not have definition for path &apos;{1}&apos;..
+        /// </summary>
+        internal static string PathDefinitionDoesntExist {
+            get {
+                return ResourceManager.GetString("PathDefinitionDoesntExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Service &apos;{0}&apos; does not exist in configuration section &apos;{1}&apos;..
+        /// </summary>
+        internal static string ServiceDefinitionDoesntExist {
+            get {
+                return ResourceManager.GetString("ServiceDefinitionDoesntExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Request returned unknown status code: {0}..
         /// </summary>
         internal static string UnknownStatusCode {

--- a/src/Kros.AspNetCore/Properties/Resources.resx
+++ b/src/Kros.AspNetCore/Properties/Resources.resx
@@ -141,6 +141,16 @@
   <data name="NotFound" xml:space="preserve">
     <value>Resource was not found.</value>
   </data>
+  <data name="PathDefinitionDoesntExist" xml:space="preserve">
+    <value>Service '{0}' does not have definition for path '{1}'.</value>
+    <comment>0- Service name
+1 - Path name</comment>
+  </data>
+  <data name="ServiceDefinitionDoesntExist" xml:space="preserve">
+    <value>Service '{0}' does not exist in configuration section '{1}'.</value>
+    <comment>0- Service name
+1 - Section name</comment>
+  </data>
   <data name="UnknownStatusCode" xml:space="preserve">
     <value>Request returned unknown status code: {0}.</value>
     <comment>0 - status code</comment>

--- a/src/Kros.AspNetCore/ServiceDiscovery/IServiceDiscoveryProvider.cs
+++ b/src/Kros.AspNetCore/ServiceDiscovery/IServiceDiscoveryProvider.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Kros.AspNetCore.ServiceDiscovery
+{
+    /// <summary>
+    /// Interface which describe provider for obtaining service address.
+    /// </summary>
+    public interface IServiceDiscoveryProvider
+    {
+        /// <summary>
+        /// Gets the service URI.
+        /// </summary>
+        /// <param name="serviceName">Name of the service.</param>
+        /// <returns>Service URI if exist.</returns>
+        /// <exception cref="ArgumentException">If service <paramref name="serviceName"/> does not exist.</exception>
+        Uri GetService(string serviceName);
+
+        /// <summary>
+        /// Gets the specific path.
+        /// </summary>
+        /// <param name="serviceName">Name of the service.</param>
+        /// <param name="pathName">Name of the path.</param>
+        /// <returns>
+        /// URI <paramref name="serviceName"/><paramref name="pathName"/>
+        /// </returns>
+        /// <exception cref="ArgumentException">If service <paramref name="serviceName"/> does not exist.</exception>
+        Uri GetPath(string serviceName, string pathName);
+    }
+}

--- a/src/Kros.AspNetCore/ServiceDiscovery/ServiceCollectionExtensions.cs
+++ b/src/Kros.AspNetCore/ServiceDiscovery/ServiceCollectionExtensions.cs
@@ -16,12 +16,12 @@ namespace Kros.AspNetCore.ServiceDiscovery
         /// <param name="options">The configure.</param>
         public static IServiceCollection AddServiceDiscovery(
             this IServiceCollection services,
-            Action<ServiceDiscoveryOption> options = null)
+            Action<ServiceDiscoveryOptions> options = null)
         {
-            options?.Invoke(ServiceDiscoveryOption.Default);
+            options?.Invoke(ServiceDiscoveryOptions.Default);
 
             services.AddScoped<IServiceDiscoveryProvider>((f) =>
-                new ServiceDiscoveryProvider(f.GetService<IConfiguration>(), ServiceDiscoveryOption.Default));
+                new ServiceDiscoveryProvider(f.GetService<IConfiguration>(), ServiceDiscoveryOptions.Default));
 
             return services;
         }

--- a/src/Kros.AspNetCore/ServiceDiscovery/ServiceCollectionExtensions.cs
+++ b/src/Kros.AspNetCore/ServiceDiscovery/ServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Kros.AspNetCore.ServiceDiscovery
+{
+    /// <summary>
+    /// Extensions for <see cref="IConfiguration"/>.
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the service discovery.
+        /// </summary>
+        /// <param name="services">The services.</param>
+        /// <param name="options">The configure.</param>
+        public static IServiceCollection AddServiceDiscovery(
+            this IServiceCollection services,
+            Action<ServiceDiscoveryOption> options = null)
+        {
+            options?.Invoke(ServiceDiscoveryOption.Default);
+
+            services.AddScoped<IServiceDiscoveryProvider>((f) =>
+                new ServiceDiscoveryProvider(f.GetService<IConfiguration>(), ServiceDiscoveryOption.Default));
+
+            return services;
+        }
+    }
+}

--- a/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryOption.cs
+++ b/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryOption.cs
@@ -1,0 +1,18 @@
+﻿namespace Kros.AspNetCore.ServiceDiscovery
+{
+    /// <summary>
+    /// Options for <see cref="ServiceDiscoveryProvider"/>
+    /// </summary>
+    public class ServiceDiscoveryOption
+    {
+        /// <summary>
+        /// Gets or sets the name of the section where is store information about services.
+        /// </summary>
+        public string SectionName { get; set; } = "Services";
+
+        /// <summary>
+        /// Gets the default instance.
+        /// </summary>
+        public static ServiceDiscoveryOption Default { get; } = new ServiceDiscoveryOption();
+    }
+}

--- a/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryOptions.cs
+++ b/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryOptions.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Options for <see cref="ServiceDiscoveryProvider"/>
     /// </summary>
-    public class ServiceDiscoveryOption
+    public class ServiceDiscoveryOptions
     {
         /// <summary>
         /// Gets or sets the name of the section where is store information about services.
@@ -13,6 +13,6 @@
         /// <summary>
         /// Gets the default instance.
         /// </summary>
-        public static ServiceDiscoveryOption Default { get; } = new ServiceDiscoveryOption();
+        public static ServiceDiscoveryOptions Default { get; } = new ServiceDiscoveryOptions();
     }
 }

--- a/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
+++ b/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
@@ -43,7 +43,6 @@ namespace Kros.AspNetCore.ServiceDiscovery
             return uriBuilder.Uri;
         }
 
-
         /// <inheritdoc />
         public Uri GetService(string serviceName)
         {

--- a/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
+++ b/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
@@ -13,14 +13,14 @@ namespace Kros.AspNetCore.ServiceDiscovery
     public class ServiceDiscoveryProvider : IServiceDiscoveryProvider
     {
         private readonly IConfiguration _configuration;
-        private readonly ServiceDiscoveryOption _option;
+        private readonly ServiceDiscoveryOptions _option;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceDiscoveryProvider"/> class.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="option">The option.</param>
-        public ServiceDiscoveryProvider(IConfiguration configuration, ServiceDiscoveryOption option)
+        public ServiceDiscoveryProvider(IConfiguration configuration, ServiceDiscoveryOptions option)
         {
             _configuration = Check.NotNull(configuration, nameof(configuration));
             _option = Check.NotNull(option, nameof(option));

--- a/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
+++ b/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
@@ -56,6 +56,5 @@ namespace Kros.AspNetCore.ServiceDiscovery
 
             return new Uri(uri);
         }
-
     }
 }

--- a/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
+++ b/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
@@ -1,0 +1,41 @@
+﻿using Kros.Utils;
+using Microsoft.Extensions.Configuration;
+using System;
+
+namespace Kros.AspNetCore.ServiceDiscovery
+{
+    /// <summary>
+    /// Provider for obtaining service address from configuration.
+    /// </summary>
+    /// <seealso cref="Kros.AspNetCore.ServiceDiscovery.IServiceDiscoveryProvider" />
+    public class ServiceDiscoveryProvider : IServiceDiscoveryProvider
+    {
+        private readonly IConfiguration _configuration;
+        private readonly ServiceDiscoveryOption _option;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceDiscoveryProvider"/> class.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="option">The option.</param>
+        public ServiceDiscoveryProvider(IConfiguration configuration, ServiceDiscoveryOption option)
+        {
+            _configuration = Check.NotNull(configuration, nameof(configuration));
+            _option = Check.NotNull(option, nameof(option));
+        }
+
+        /// <inheritdoc />
+        public Uri GetPath(string serviceName, string pathName)
+        {
+            var uriBuilder = new UriBuilder(GetService(serviceName));
+            uriBuilder.Path = _configuration.GetValue<string>($"{_option.SectionName}:{serviceName}:Paths:{pathName}");
+
+            return uriBuilder.Uri;
+        }
+
+
+        /// <inheritdoc />
+        public Uri GetService(string serviceName)
+            => new Uri(_configuration.GetValue<string>($"{_option.SectionName}:{serviceName}:DownstreamPath"));
+    }
+}

--- a/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
@@ -21,6 +21,8 @@ namespace Kros.AspNetCore.Tests.Authorization
     {
         private const string AuthorizationUrl = "http://authorizationservice.com";
         private const string HashAuthorizationUrl = "http://hashauthorizationservice.com";
+        private const string JwtToken = "MyJwtToken";
+        private const string HashJwtToken = "HashJwtToken";
 
         [Fact]
         public async void AddJwtTokenIntoHeader()
@@ -178,7 +180,7 @@ namespace Kros.AspNetCore.Tests.Authorization
 
             cache.Get(HashCode.Combine(accessToken, context.Request.Path))
                 .Should()
-                .Be("MyJwtToken");
+                .Be(JwtToken);
         }
 
         [Fact]
@@ -194,7 +196,7 @@ namespace Kros.AspNetCore.Tests.Authorization
 
             cache.Get(HashCode.Combine(context.Request.Query["hash"].ToString(), context.Request.Path))
                 .Should()
-                .Be("HashJwtToken");
+                .Be(HashJwtToken);
         }
 
         [Fact]
@@ -360,14 +362,14 @@ namespace Kros.AspNetCore.Tests.Authorization
                 new HttpResponseMessage()
                 {
                     StatusCode = statusCode,
-                    Content = new StringContent("MyJwtToken")
+                    Content = new StringContent(JwtToken)
                 }));
             responses.Add(new KeyValuePair<FakeHttpMessageHandler.HttpRequestFilter, HttpResponseMessage>(
                 (req) => req.RequestUri.AbsoluteUri.Contains(HashAuthorizationUrl),
                 new HttpResponseMessage()
                 {
                     StatusCode = statusCode,
-                    Content = new StringContent("HashJwtToken")
+                    Content = new StringContent(HashJwtToken)
                 }));
 
             return new FakeHttpMessageHandler(responses);
@@ -380,6 +382,5 @@ namespace Kros.AspNetCore.Tests.Authorization
 
             return provider;
         }
-
     }
 }

--- a/tests/Kros.AspNetCore.Tests/Kros.AspNetCore.Tests.csproj
+++ b/tests/Kros.AspNetCore.Tests/Kros.AspNetCore.Tests.csproj
@@ -34,4 +34,10 @@
     <ProjectReference Include="..\..\src\Kros.AspNetCore\Kros.AspNetCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="servicediscoveryAppsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceCollectionExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceCollectionExtensionsShould.cs
@@ -1,0 +1,25 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Kros.AspNetCore.ServiceDiscovery
+{
+    public class ServiceCollectionExtensionsShould
+    {
+        [Fact]
+        public void RegisterServiceDiscoveryProvider()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+
+            serviceCollection.AddServiceDiscovery();
+
+            IServiceDiscoveryProvider provider =  serviceCollection
+                .BuildServiceProvider()
+                .GetService<IServiceDiscoveryProvider>();
+
+            provider.Should().NotBeNull();
+        }
+    }
+}

--- a/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
+++ b/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
@@ -35,6 +35,18 @@ namespace Kros.AspNetCore.Tests.ServiceDiscovery
         }
 
         [Fact]
+        public void FindServiceUriByNameInAnoutherSection()
+        {
+            var provider = new ServiceDiscoveryProvider(
+                GetConfiguration(),
+                new ServiceDiscoveryOption() { SectionName = "ApiServices" });
+
+            Uri uri = provider.GetService("ToDos");
+
+            uri.AbsoluteUri.Should().Be("http://localhost:9004/");
+        }
+
+        [Fact]
         public void ThrowExceptionIfServiceDoesntExist()
         {
             var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOption.Default);

--- a/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
+++ b/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
@@ -35,7 +35,7 @@ namespace Kros.AspNetCore.Tests.ServiceDiscovery
         }
 
         [Fact]
-        public void FindServiceUriByNameInAnoutherSection()
+        public void FindServiceUriByNameInAnotherSection()
         {
             var provider = new ServiceDiscoveryProvider(
                 GetConfiguration(),

--- a/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
+++ b/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
@@ -1,0 +1,42 @@
+﻿using FluentAssertions;
+using Kros.AspNetCore.ServiceDiscovery;
+using Microsoft.Extensions.Configuration;
+using System;
+using Xunit;
+
+namespace Kros.AspNetCore.Tests.ServiceDiscovery
+{
+    public class ServiceDiscoveryShould
+    {
+        [Theory]
+        [InlineData("Users", "http://localhost:9003/")]
+        [InlineData("Projects", "http://localhost:9002/")]
+        [InlineData("Authorization", "https://authorizationservice.domain.com/")]
+        public void FindServiceUriByName(string serviceName, string expectedUri)
+        {
+            var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOption.Default);
+
+            Uri uri = provider.GetService(serviceName);
+
+            uri.AbsoluteUri.Should().Be(expectedUri);
+        }
+
+        [Theory]
+        [InlineData("Users", "getAll", "http://localhost:9003/api/users")]
+        [InlineData("Users", "getById", "http://localhost:9003/api/users/{id}")]
+        [InlineData("Projects", "create", "http://localhost:9002/api/projects")]
+        public void FindPathUriByServiceAndPathName(string serviceName, string pathName, string expectedUri)
+        {
+            var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOption.Default);
+
+            Uri uri = provider.GetPath(serviceName, pathName);
+
+            uri.ToString().Should().Be(expectedUri);
+        }
+
+        private static IConfiguration GetConfiguration() =>
+            new ConfigurationBuilder()
+                .AddJsonFile("servicediscoveryAppsettings.json")
+                .Build();
+    }
+}

--- a/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
+++ b/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
@@ -14,7 +14,7 @@ namespace Kros.AspNetCore.Tests.ServiceDiscovery
         [InlineData("Authorization", "https://authorizationservice.domain.com/")]
         public void FindServiceUriByName(string serviceName, string expectedUri)
         {
-            var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOption.Default);
+            var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOptions.Default);
 
             Uri uri = provider.GetService(serviceName);
 
@@ -27,7 +27,7 @@ namespace Kros.AspNetCore.Tests.ServiceDiscovery
         [InlineData("Projects", "create", "http://localhost:9002/api/projects")]
         public void FindPathUriByServiceAndPathName(string serviceName, string pathName, string expectedUri)
         {
-            var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOption.Default);
+            var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOptions.Default);
 
             Uri uri = provider.GetPath(serviceName, pathName);
 
@@ -39,7 +39,7 @@ namespace Kros.AspNetCore.Tests.ServiceDiscovery
         {
             var provider = new ServiceDiscoveryProvider(
                 GetConfiguration(),
-                new ServiceDiscoveryOption() { SectionName = "ApiServices" });
+                new ServiceDiscoveryOptions() { SectionName = "ApiServices" });
 
             Uri uri = provider.GetService("ToDos");
 
@@ -49,7 +49,7 @@ namespace Kros.AspNetCore.Tests.ServiceDiscovery
         [Fact]
         public void ThrowExceptionIfServiceDoesntExist()
         {
-            var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOption.Default);
+            var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOptions.Default);
 
             Action action = () => provider.GetService("doesntExist");
 
@@ -62,7 +62,7 @@ namespace Kros.AspNetCore.Tests.ServiceDiscovery
         [InlineData("doesntExist", "getById")]
         public void ThrowExceptionIfServiceOrPathDoesntExist(string serviceName, string pathName)
         {
-            var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOption.Default);
+            var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOptions.Default);
 
             Action action = () => provider.GetPath(serviceName, pathName);
 

--- a/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
+++ b/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
@@ -34,6 +34,29 @@ namespace Kros.AspNetCore.Tests.ServiceDiscovery
             uri.ToString().Should().Be(expectedUri);
         }
 
+        [Fact]
+        public void ThrowExceptionIfServiceDoesntExist()
+        {
+            var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOption.Default);
+
+            Action action = () => provider.GetService("doesntExist");
+
+            action.Should().Throw<ArgumentException>();
+        }
+
+        [Theory]
+        [InlineData("Users", "create")]
+        [InlineData("projects", "getById")]
+        [InlineData("doesntExist", "getById")]
+        public void ThrowExceptionIfServiceOrPathDoesntExist(string serviceName, string pathName)
+        {
+            var provider = new ServiceDiscoveryProvider(GetConfiguration(), ServiceDiscoveryOption.Default);
+
+            Action action = () => provider.GetPath(serviceName, pathName);
+
+            action.Should().Throw<ArgumentException>();
+        }
+
         private static IConfiguration GetConfiguration() =>
             new ConfigurationBuilder()
                 .AddJsonFile("servicediscoveryAppsettings.json")

--- a/tests/Kros.AspNetCore.Tests/servicediscoveryAppsettings.json
+++ b/tests/Kros.AspNetCore.Tests/servicediscoveryAppsettings.json
@@ -1,0 +1,26 @@
+{
+  "Services": {
+    "Users": {
+      "DownstreamPath": "http://localhost:9003",
+      "Paths": {
+        "getAll": "/api/users",
+        "getById":  "/api/users/{id}"
+      }
+    },
+    "projects": {
+      "DownstreamPath": "http://localhost:9002",
+      "Paths": {
+        "create": "/api/projects"
+      }
+    },
+    "Authorization": {
+      "DownstreamPath": "https://authorizationService.domain.com"
+    }
+  },
+
+  "ApiServices": {
+    "ToDos": {
+      "DownstreamPath": "http://localhost:9004"
+    }
+  }
+}

--- a/tests/Kros.AspNetCore.Tests/servicediscoveryAppsettings.json
+++ b/tests/Kros.AspNetCore.Tests/servicediscoveryAppsettings.json
@@ -1,15 +1,15 @@
 {
   "Services": {
     "Users": {
-      "DownstreamPath": "http://localhost:9003",
-      "Paths": {
+      "downstreamPath": "http://localhost:9003",
+      "paths": {
         "getAll": "/api/users",
         "getById":  "/api/users/{id}"
       }
     },
     "projects": {
       "DownstreamPath": "http://localhost:9002",
-      "Paths": {
+      "paths": {
         "create": "/api/projects"
       }
     },


### PR DESCRIPTION
### Service Discovery Provider

Častokrát sa stáva, že niektorá služba potrebuje robiť dotaz na inú službu. V taktomto prípade býva niekde v settingoch konfigurácia, ktorá obsahuje adresu danej služby. Keďže už v rámci ApiGateway budeme používať [Service Discovery Provider](https://github.com/Burgyn/MMLib.Ocelot.Provider.AppConfiguration) na definíciu služieb. Tak tieto konfigurácie môžme využiť aj na to aby sme nemuseli zbytočne vo všetkých službách definovať tie isté adresy.

#### Get started

1. Definujme si služby

```json
"Services": {
  "organizations": {
    "DownstreamPath": "http://localhost:9003"
  },
  "authorization": {
    "DownstreamPath": "http://localhost:9002",
    "Paths":{
      "jwt": "/api/authorization/jwt-token"
    }
  },
  "toDos": {
    "DownstreamPath": "http://localhost:9001"
  }
}
```

> Ideálne však v Azure AppConfiguration, aby sme jednotlivé definície mohli zdieľať naprieš službami.

2. Pridajme si `IServiceDiscoveryProvider`

```CSharp
services.AddServiceDiscovery();
```

3. Použime `IServiceDiscoveryProvider` injecnutý do vašich tried

```CSharp
provider.GetPath("authorization","jwt");
```

#### GatewayAuthorizationMiddleware

Už aj `GatewayAuthorizationMiddleware` podporuje `IServiceDiscoveryProvider`

```json
"GatewayJwtAuthorization": {
    "Authorization": {
      "ServiceName": "authorization",
      "PathName": "jwt"
    },
    "HashAuthorization": {
      "ServiceName": "authorization",
      "PathName": "jwt"
    },
    "CacheSlidingExpirationOffset": "00:00:00",
    "IgnoredPathForCache": [
      "/organizations"
    ]
  }
```
