### PR TITLE
Added support for multiple JWT auth schemes.

### DIFF
--- a/src/Kros.AspNetCore/Authorization/ApiJwtAuthorizationOptions.cs
+++ b/src/Kros.AspNetCore/Authorization/ApiJwtAuthorizationOptions.cs
@@ -1,18 +1,13 @@
 ﻿namespace Kros.AspNetCore.Authorization
 {
     /// <summary>
-    /// JWT authorization options for api services.
+    /// JWT authorization options for api services. Contains all authorization schemes.
     /// </summary>
     public class ApiJwtAuthorizationOptions
     {
         /// <summary>
-        /// Secret for jwt digital sign.
+        /// List of schemes.
         /// </summary>
-        public string JwtSecret { get; set; }
-
-        /// <summary>
-        /// Https is required. Default value is <see langword="true"/>.
-        /// </summary>
-        public bool RequireHttpsMetadata { get; set; } = true;
+        public ApiJwtAuthorizationScheme[] Schemes { get; set; }
     }
 }

--- a/src/Kros.AspNetCore/Authorization/ApiJwtAuthorizationScheme.cs
+++ b/src/Kros.AspNetCore/Authorization/ApiJwtAuthorizationScheme.cs
@@ -1,0 +1,23 @@
+﻿namespace Kros.AspNetCore.Authorization
+{
+    /// <summary>
+    /// JWT authorization options for api services. Contains one authorization scheme.
+    /// </summary>
+    public class ApiJwtAuthorizationScheme
+    {
+        /// <summary>
+        /// Scheme name.
+        /// </summary>
+        public string SchemeName { get; set; }
+
+        /// <summary>
+        /// Secret for jwt digital sign.
+        /// </summary>
+        public string JwtSecret { get; set; }
+
+        /// <summary>
+        /// Https is required. Default value is <see langword="true"/>.
+        /// </summary>
+        public bool RequireHttpsMetadata { get; set; } = true;
+    }
+}

--- a/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
@@ -29,7 +29,7 @@ namespace Kros.AspNetCore.Authorization
         public string HashAuthorizationUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the authorization.
+        /// Gets or sets the hash authorization.
         /// </summary>
         public AuthorizationServiceOptions HashAuthorization { get; set; }
 

--- a/src/Kros.AspNetCore/Authorization/JwtAuthorizationHelper.cs
+++ b/src/Kros.AspNetCore/Authorization/JwtAuthorizationHelper.cs
@@ -18,6 +18,11 @@ namespace Kros.AspNetCore.Authorization
         public const string JwtSchemeName = "JwtAuthorization";
 
         /// <summary>
+        /// Hash jwt authentication scheme name.
+        /// </summary>
+        public const string HashJwtSchemeName = "JwtHashAuthorization";
+
+        /// <summary>
         /// OAuth authentication scheme name.
         /// </summary>
         public const string OAuthSchemeName = "OAuthAuthorization";

--- a/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
+++ b/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
@@ -1,8 +1,11 @@
-﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Kros.AspNetCore.Authorization
@@ -35,23 +38,60 @@ namespace Kros.AspNetCore.Authorization
             IConfiguration configuration,
             Action<JwtBearerOptions> configureOptions = null)
         {
-            ApiJwtAuthorizationOptions options = configuration.GetSection<ApiJwtAuthorizationOptions>();
+            return AddApiJwtAuthentication(services, new string[] { scheme }, configuration, configureOptions);
+        }
 
-            services.AddAuthentication(scheme)
-                .AddJwtBearer(scheme, x =>
+        /// <summary>
+        /// Configure downstream api authentication.
+        /// </summary>
+        /// <param name="services">Collection of app services.</param>
+        /// <param name="schemeNames">Scheme names for authentication.</param>
+        /// <param name="configuration">Configuration from which the options are loaded.</param>
+        /// <param name="configureOptions">Configuration.</param>
+        public static IServiceCollection AddApiJwtAuthentication(
+            this IServiceCollection services,
+            IEnumerable<string> schemeNames,
+            IConfiguration configuration,
+            Action<JwtBearerOptions> configureOptions = null)
+        {
+            ApiJwtAuthorizationOptions configuredOptionsList = configuration.GetSection<ApiJwtAuthorizationOptions>();
+            IEnumerable<ApiJwtAuthorizationScheme> schemeList = (from scheme in configuredOptionsList.Schemes
+                                                                 where schemeNames.Contains(scheme.SchemeName)
+                                                                 select scheme);
+
+            if (!schemeList.Any())
+            {
+                throw new ArgumentException("No valid schemes for Api JWT authentication", nameof(schemeNames));
+            }
+
+            AuthenticationBuilder builder;
+
+            if (schemeList.Count() == 1)
+            {
+                builder = services.AddAuthentication(schemeList.First().SchemeName);
+            }
+            else
+            {
+                builder = services.AddAuthentication();
+            }
+
+            foreach (var scheme in schemeList)
+            {
+                builder = builder.AddJwtBearer(scheme.SchemeName, x =>
                 {
-                    x.RequireHttpsMetadata = options.RequireHttpsMetadata;
+                    x.RequireHttpsMetadata = scheme.RequireHttpsMetadata;
                     x.SaveToken = false;
                     x.TokenValidationParameters = new TokenValidationParameters
                     {
                         ValidateIssuerSigningKey = true,
-                        IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(options.JwtSecret)),
+                        IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(scheme.JwtSecret)),
                         ValidateIssuer = false,
                         ValidateAudience = false
                     };
 
                     configureOptions?.Invoke(x);
                 });
+            }
 
             return services;
         }

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <Version>2.6.1</Version>
+    <Version>2.7.0</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>

--- a/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceCollectionExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceCollectionExtensionsShould.cs
@@ -1,6 +1,12 @@
 ﻿using FluentAssertions;
+using Kros.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace Kros.AspNetCore.ServiceDiscovery
@@ -20,6 +26,65 @@ namespace Kros.AspNetCore.ServiceDiscovery
                 .GetService<IServiceDiscoveryProvider>();
 
             provider.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void AddApiJwtAuthenticationShouldAddOneScheme()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddApiJwtAuthentication(new string[] { JwtAuthorizationHelper.JwtSchemeName }, GetConfiguration());
+            serviceCollection.AddLogging(x => new object());
+            serviceCollection.BuildServiceProvider().GetServices<JwtBearerHandler>().Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void AddApiJwtAuthenticationShouldAddMultipleSchemes()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddApiJwtAuthentication(
+                new string[] { JwtAuthorizationHelper.JwtSchemeName, JwtAuthorizationHelper.HashJwtSchemeName },
+                GetConfiguration());
+            serviceCollection.AddLogging(x => new object());
+            serviceCollection.BuildServiceProvider().GetServices<JwtBearerHandler>().Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void AddApiJwtAuthenticationRequiresAtLeastOneScheme()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.Invoking(sc =>  sc.AddApiJwtAuthentication(new string[] { }, GetConfiguration()))
+                .Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void AddApiJwtAuthenticationIgnoresUnconfiguredSchemes()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.Invoking(sc => sc.AddApiJwtAuthentication(new string[] { "unknown" }, GetConfiguration()))
+                .Should().Throw<ArgumentException>();
+        }
+
+        private IConfiguration GetConfiguration()
+        {
+            var cfg = @"{
+                    ""ApiJwtAuthorization"": {
+                        ""Schemes"": [
+                          {
+                            ""SchemeName"": ""JwtAuthorization"",
+                            ""JwtSecret"": ""secret1"",
+                            ""RequireHttpsMetadata"": true
+                          },
+                          {
+                            ""SchemeName"": ""JwtHashAuthorization"",
+                            ""JwtSecret"": ""secret2"",
+                            ""RequireHttpsMetadata"": true
+                          }
+                        ]
+                       }
+                    }";
+            var cfgBuilder = new ConfigurationBuilder();
+            cfgBuilder.AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(cfg)));
+            return cfgBuilder.Build();
         }
     }
 }


### PR DESCRIPTION
Added support for multiple JWT auth schemes. It is now possible to configure multiple JWT auth schemes and add them via an overload of `AddApiJwtAuthentication`.

Breaking change: settings of ApiJwtAuthorization are now in a different format, because there is an array of schemes.

Old configuration:
```json
"ApiJwtAuthorization": {
    "JwtSecret": "",
    "RequireHttpsMetadata": true
  }
```

New configuration:

  ```json
"ApiJwtAuthorization": {
    "Schemes": [
      {
        "Scheme": "JwtAuthorization",
        "JwtSecret": "",
        "RequireHttpsMetadata": true
      },
      {
        "Scheme": "JwtHashAuthorization",
        "JwtSecret": "",
        "RequireHttpsMetadata": true
      }
    ]
}
  ```