### PR TITLE
Prefix for MassTransit topics.

### DIFF
--- a/src/Kros.MassTransit.AzureServiceBus/AzureServiceBusOptions.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/AzureServiceBusOptions.cs
@@ -38,6 +38,12 @@ namespace Kros.MassTransit.AzureServiceBus
         public int TokenTimeToLive { get; set; }
 
         /// <summary>
+        /// Message type prefix.
+        /// </summary>
+        /// <remarks>Used by MassTransit for creating topic names.</remarks>
+        public string MessageTypePrefix { get; set; }
+
+        /// <summary>
         /// Dictionary of supported service bus endpoints.
         /// </summary>
         public Dictionary<string, AzureServiceBusEndpoint> Endpoints { get; set; }

--- a/src/Kros.MassTransit.AzureServiceBus/AzureServiceBusOptions.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/AzureServiceBusOptions.cs
@@ -38,10 +38,10 @@ namespace Kros.MassTransit.AzureServiceBus
         public int TokenTimeToLive { get; set; }
 
         /// <summary>
-        /// Message type prefix.
+        /// Topic name prefix.
         /// </summary>
         /// <remarks>Used by MassTransit for creating topic names.</remarks>
-        public string MessageTypePrefix { get; set; }
+        public string TopicNamePrefix { get; set; }
 
         /// <summary>
         /// Dictionary of supported service bus endpoints.

--- a/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
+++ b/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>1.0.0-alpha.5</Version>
+    <Version>1.0.0-alpha.6</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>Simpler configuration of MassTransit library.</Description>

--- a/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
+++ b/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <Version>1.0.0-alpha.4</Version>
+    <Version>1.0.0-alpha.5</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>Simpler configuration of MassTransit library.</Description>

--- a/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
+++ b/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <Version>1.0.0-alpha.3</Version>
+    <Version>1.0.0-alpha.4</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>Simpler configuration of MassTransit library.</Description>

--- a/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
@@ -21,7 +21,7 @@ namespace Kros.MassTransit.AzureServiceBus
         private readonly string _connectionString;
         private TimeSpan _tokenTimeToLive;
         private readonly IServiceProvider _provider;
-        private readonly string _messageTypePrefix;
+        private readonly string _topicNamePrefix;
         private Action<IServiceBusBusFactoryConfigurator, IServiceBusHost> _busConfigurator;
         private readonly List<Endpoint> _endpoints = new List<Endpoint>();
         private Endpoint _currentEndpoint;
@@ -69,7 +69,7 @@ namespace Kros.MassTransit.AzureServiceBus
                 ? TimeSpan.FromSeconds(options.TokenTimeToLive)
                 : ConfigDefaults.TokenTimeToLive;
             _provider = provider;
-            _messageTypePrefix = options.MessageTypePrefix;
+            _topicNamePrefix = options.TopicNamePrefix;
         }
 
         /// <summary>
@@ -233,10 +233,10 @@ namespace Kros.MassTransit.AzureServiceBus
 
         private void AddMessageTypePrefix(IServiceBusBusFactoryConfigurator configurator)
         {
-            if (!string.IsNullOrWhiteSpace(_messageTypePrefix))
+            if (!string.IsNullOrWhiteSpace(_topicNamePrefix))
             {
                 configurator.MessageTopology.SetEntityNameFormatter(
-                    new PrefixEntityNameFormatter(configurator.MessageTopology.EntityNameFormatter, _messageTypePrefix));
+                    new PrefixEntityNameFormatter(configurator.MessageTopology.EntityNameFormatter, _topicNamePrefix));
             }
         }
 

--- a/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
@@ -240,7 +240,6 @@ namespace Kros.MassTransit.AzureServiceBus
             }
         }
 
-
         #endregion
     }
 }

--- a/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
@@ -21,6 +21,7 @@ namespace Kros.MassTransit.AzureServiceBus
         private readonly string _connectionString;
         private TimeSpan _tokenTimeToLive;
         private readonly IServiceProvider _provider;
+        private readonly string _messageTypePrefix;
         private Action<IServiceBusBusFactoryConfigurator, IServiceBusHost> _busConfigurator;
         private readonly List<Endpoint> _endpoints = new List<Endpoint>();
         private Endpoint _currentEndpoint;
@@ -68,6 +69,7 @@ namespace Kros.MassTransit.AzureServiceBus
                 ? TimeSpan.FromSeconds(options.TokenTimeToLive)
                 : ConfigDefaults.TokenTimeToLive;
             _provider = provider;
+            _messageTypePrefix = options.MessageTypePrefix;
         }
 
         /// <summary>
@@ -167,6 +169,7 @@ namespace Kros.MassTransit.AzureServiceBus
                 IServiceBusHost host = CreateServiceHost(busCfg);
 
                 ConfigureServiceBus(busCfg, host);
+                AddMessageTypePrefix(busCfg);
                 AddEndpoints(busCfg);
 
                 if (_provider != null)
@@ -227,6 +230,16 @@ namespace Kros.MassTransit.AzureServiceBus
                 endpoint.SetEndpoint(busCfg);
             }
         }
+
+        private void AddMessageTypePrefix(IServiceBusBusFactoryConfigurator configurator)
+        {
+            if (!string.IsNullOrWhiteSpace(_messageTypePrefix))
+            {
+                configurator.MessageTopology.SetEntityNameFormatter(
+                    new PrefixEntityNameFormatter(configurator.MessageTopology.EntityNameFormatter, _messageTypePrefix));
+            }
+        }
+
 
         #endregion
     }

--- a/src/Kros.MassTransit.AzureServiceBus/PrefixEntityNameFormatter.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/PrefixEntityNameFormatter.cs
@@ -1,0 +1,29 @@
+﻿using Kros.Utils;
+using MassTransit.Topology;
+
+namespace Kros.MassTransit.AzureServiceBus
+{
+    /// <summary>
+    /// Entity name formatter for MassTransit with prefixes.
+    /// </summary>
+    class PrefixEntityNameFormatter: IEntityNameFormatter
+    {
+        private readonly IEntityNameFormatter _originalFormatter;
+        private readonly string _prefix;
+
+        /// <summary>
+        /// Contructor.
+        /// </summary>
+        /// <param name="originalFormatter">Original formatter.</param>
+        /// <param name="messageTypePrefix">Prefix for message type.</param>
+        public PrefixEntityNameFormatter(IEntityNameFormatter originalFormatter, string messageTypePrefix)
+        {
+            _originalFormatter = Check.NotNull(originalFormatter, nameof(originalFormatter));
+            _prefix = Check.NotNullOrWhiteSpace(messageTypePrefix, nameof(messageTypePrefix));
+        }
+
+        /// <inheritdoc/>
+        public string FormatEntityName<T>()
+            => $"{_prefix}-{_originalFormatter.FormatEntityName<T>()}";
+    }
+}


### PR DESCRIPTION
Closes #83.

Support for message type prefix. Autogenerated topic names of MassTransit will includes prefix. Final topic endpoint will be:
`{serviceBusAddress}/{Prefix}-{Namespace/MessageName}`.
Char `/` was not supported, and `.` was not visible in debug console in my opinion.