### PR TITLE
Add support for reading Azure feature flags during reading Azure app …

### DIFF
--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -57,6 +57,15 @@ namespace Kros.AspNetCore.Extensions
                         .Select($"{service}:*", hostingContext.HostingEnvironment.EnvironmentName)
                         .TrimKeyPrefix($"{service}:");
                 }
+
+                string useFeatureFlagsSetting = settings["AppConfig:UseFeatureFlags"];
+                if (bool.TryParse(useFeatureFlagsSetting, out bool useFeatureFlags) && useFeatureFlags)
+                {
+                    options
+                        .Select("_", LabelFilter.Null)
+                        .Select("_", hostingContext.HostingEnvironment.EnvironmentName)
+                        .UseFeatureFlags();
+                }
             });
 
             return config;


### PR DESCRIPTION
Add support for reading Azure feature flags during reading Azure app configuration.
Reading Azure feature flags is possible turn on with option `AppConfig:UseFeatureFlags` in appsetting file.

Closes #91 
