### PR TITLE
JwtAutorizationOptions.hashParameterName can be null.

### DIFF
--- a/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
@@ -90,7 +90,8 @@ namespace Kros.AspNetCore.Authorization
 
                 return jwtToken;
             }
-            else if (httpContext.Request.Query.TryGetValue(_jwtAuthorizationOptions.HashParameterName, out StringValues hashValue))
+            else if (!string.IsNullOrEmpty(_jwtAuthorizationOptions.HashParameterName)
+                && httpContext.Request.Query.TryGetValue(_jwtAuthorizationOptions.HashParameterName, out StringValues hashValue))
             {
                 int key = GetKey(httpContext, hashValue.ToString());
                 if (!memoryCache.TryGetValue(key, out string jwtToken))

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>2.11.0</Version>
+    <Version>2.11.1</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>


### PR DESCRIPTION
_jwtAuthorizationOptions.HashParameterName can be null.