### PR TITLE
App configuration extension method with environment name parameter

### DIFF
--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -30,7 +30,7 @@ namespace Kros.AspNetCore.Extensions
         /// <remarks>
         /// Configuration should contain attributes AppConfig:Endpoint and AppConfig:Settings.
         /// </remarks>
-        public static IConfigurationBuilder AddAzureAppConfiguration(
+        public static IConfigurationBuilder AddAzureAppConfig(
             this IConfigurationBuilder config, string environmentName)
         {
             var settings = config.Build();
@@ -82,7 +82,7 @@ namespace Kros.AspNetCore.Extensions
             this IConfigurationBuilder config,
             HostBuilderContext hostingContext)
         {
-            return config.AddAzureAppConfiguration(hostingContext.HostingEnvironment.EnvironmentName);
+            return config.AddAzureAppConfig(hostingContext.HostingEnvironment.EnvironmentName);
         }
     }
 }

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -80,9 +80,6 @@ namespace Kros.AspNetCore.Extensions
         /// </remarks>
         public static IConfigurationBuilder AddAzureAppConfiguration(
             this IConfigurationBuilder config,
-            HostBuilderContext hostingContext)
-        {
-            return config.AddAzureAppConfig(hostingContext.HostingEnvironment.EnvironmentName);
-        }
+            HostBuilderContext hostingContext) => config.AddAzureAppConfig(hostingContext.HostingEnvironment.EnvironmentName);
     }
 }

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -26,13 +26,12 @@ namespace Kros.AspNetCore.Extensions
         /// Adds the azure application configuration.
         /// </summary>
         /// <param name="config">The configuration.</param>
-        /// <param name="hostingContext">The hosting context.</param>
+        /// <param name="environmentName">Environment name.</param>
         /// <remarks>
         /// Configuration should contain attributes AppConfig:Endpoint and AppConfig:Settings.
         /// </remarks>
         public static IConfigurationBuilder AddAzureAppConfiguration(
-            this IConfigurationBuilder config,
-            HostBuilderContext hostingContext)
+            this IConfigurationBuilder config, string environmentName)
         {
             var settings = config.Build();
 
@@ -54,7 +53,7 @@ namespace Kros.AspNetCore.Extensions
                 {
                     options
                         .Select($"{service}:*", LabelFilter.Null)
-                        .Select($"{service}:*", hostingContext.HostingEnvironment.EnvironmentName)
+                        .Select($"{service}:*", environmentName)
                         .TrimKeyPrefix($"{service}:");
                 }
 
@@ -63,12 +62,27 @@ namespace Kros.AspNetCore.Extensions
                 {
                     options
                         .Select("_", LabelFilter.Null)
-                        .Select("_", hostingContext.HostingEnvironment.EnvironmentName)
+                        .Select("_", environmentName)
                         .UseFeatureFlags();
                 }
             });
 
             return config;
+        }
+
+        /// <summary>
+        /// Adds the azure application configuration.
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <param name="hostingContext">The hosting context.</param>
+        /// <remarks>
+        /// Configuration should contain attributes AppConfig:Endpoint and AppConfig:Settings.
+        /// </remarks>
+        public static IConfigurationBuilder AddAzureAppConfiguration(
+            this IConfigurationBuilder config,
+            HostBuilderContext hostingContext)
+        {
+            return config.AddAzureAppConfiguration(hostingContext.HostingEnvironment.EnvironmentName);
         }
     }
 }

--- a/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
@@ -13,27 +13,21 @@ namespace Kros.AspNetCore.Tests.Extensions
         [Fact]
         public void AddAzureAppConfigurationSource()
         {
-            // arrange
             IConfigurationBuilder config = new ConfigurationBuilder();
             HostBuilderContext builderContext = CreateHostBuilderContext();
 
-            // act
             config.AddAzureAppConfiguration(builderContext);
 
-            // assert
             config.Sources.Count.Should().Be(1);
         }
 
         [Fact]
         public void AddAzureAppConfigurationSource2()
         {
-            // arrange
             IConfigurationBuilder config = new ConfigurationBuilder();
 
-            // act
             config.AddAzureAppConfig("Development");
 
-            // assert
             config.Sources.Count.Should().Be(1);
         }
 

--- a/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
@@ -4,13 +4,14 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using System.Collections.Generic;
 using FluentAssertions;
+using NSubstitute;
 
 namespace Kros.AspNetCore.Tests.Extensions
 {
     public class ConfigurationBuilderExtensionsShould
     {
         [Fact]
-        public void AddConfigurationSource()
+        public void AddAzureAppConfigurationSource()
         {
             // arrange
             IConfigurationBuilder config = new ConfigurationBuilder();
@@ -23,10 +24,25 @@ namespace Kros.AspNetCore.Tests.Extensions
             config.Sources.Count.Should().Be(1);
         }
 
+        [Fact]
+        public void AddAzureAppConfigurationSource2()
+        {
+            // arrange
+            IConfigurationBuilder config = new ConfigurationBuilder();
+
+            // act
+            config.AddAzureAppConfig("Development");
+
+            // assert
+            config.Sources.Count.Should().Be(1);
+        }
+
         private HostBuilderContext CreateHostBuilderContext()
         {
             var context = new HostBuilderContext(new Dictionary<object, object>());
             context.Configuration = GetConfiguration();
+            context.HostingEnvironment = Substitute.For<IHostEnvironment>();
+            context.HostingEnvironment.EnvironmentName.Returns("Development");
             return context;
         }
 


### PR DESCRIPTION
Add App Configuration extension method with environment name parameter to support scenarios where HostBuilderContext is not used (for example Function Apps).
