### PR TITLE
Add AddAzureAppConfigurationIfEndpointDefined

### DIFF
--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -89,7 +89,8 @@ namespace Kros.AspNetCore.Extensions
         /// <param name="config">The configuration.</param>
         /// <param name="environmentName">Environment name.</param>
         /// <remarks>
-        /// Configuration should contain attributes AppConfig:Endpoint and AppConfig:Settings.
+        /// Configuration can contain attribute AppConfig:Endpoint. If it contains AppConfig:Endpoint,
+        /// it should contain AppConfig:Settings.
         /// </remarks>
         public static IConfigurationBuilder AddAzureAppConfigurationIfEndpointDefined(
             this IConfigurationBuilder config,

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -30,7 +30,7 @@ namespace Kros.AspNetCore.Extensions
         /// <remarks>
         /// Configuration should contain attributes AppConfig:Endpoint and AppConfig:Settings.
         /// </remarks>
-        public static IConfigurationBuilder AddAzureAppConfiguration(
+        public static IConfigurationBuilder AddAzureAppConfig(
             this IConfigurationBuilder config, string environmentName)
         {
             var settings = config.Build();
@@ -82,7 +82,7 @@ namespace Kros.AspNetCore.Extensions
             this IConfigurationBuilder config,
             HostBuilderContext hostingContext)
         {
-            return config.AddAzureAppConfiguration(hostingContext.HostingEnvironment.EnvironmentName);
+            return config.AddAzureAppConfig(hostingContext.HostingEnvironment.EnvironmentName);
         }
     }
 }

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -35,6 +35,12 @@ namespace Kros.AspNetCore.Extensions
         {
             var settings = config.Build();
 
+            string appConfigEndpoint = settings["AppConfig:Endpoint"];
+            if (string.IsNullOrWhiteSpace(appConfigEndpoint))
+            {
+                return config;
+            }
+
             config.AddAzureAppConfiguration(options =>
             {
                 var credential = new DefaultAzureCredential();
@@ -81,28 +87,5 @@ namespace Kros.AspNetCore.Extensions
         public static IConfigurationBuilder AddAzureAppConfiguration(
             this IConfigurationBuilder config,
             HostBuilderContext hostingContext) => config.AddAzureAppConfig(hostingContext.HostingEnvironment.EnvironmentName);
-
-        /// <summary>
-        /// Adds the azure application configuration if AppConfig:Endpoint is defined.
-        /// Does not throw exception if AppConfig:Endpoint is not defined.
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        /// <param name="environmentName">Environment name.</param>
-        /// <remarks>
-        /// Configuration can contain attribute AppConfig:Endpoint. If it contains AppConfig:Endpoint,
-        /// it should contain AppConfig:Settings.
-        /// </remarks>
-        public static IConfigurationBuilder AddAzureAppConfigurationIfEndpointDefined(
-            this IConfigurationBuilder config,
-            string environmentName)
-        {
-            var settings = config.Build();
-            string appConfigEndpoint = settings["AppConfig:Endpoint"];
-            if (!string.IsNullOrWhiteSpace(appConfigEndpoint))
-            {
-                config.AddAzureAppConfig(environmentName);
-            }
-            return config;
-        }
     }
 }

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -80,9 +80,6 @@ namespace Kros.AspNetCore.Extensions
         /// </remarks>
         public static IConfigurationBuilder AddAzureAppConfiguration(
             this IConfigurationBuilder config,
-            HostBuilderContext hostingContext)
-        {
-            return config.AddAzureAppConfig(hostingContext.HostingEnvironment.EnvironmentName);
-        }
+            HostBuilderContext hostingContext) => config.AddAzureAppConfig(hostingContext.HostingEnvironment.EnvironmentName);
     }
 }

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -26,13 +26,12 @@ namespace Kros.AspNetCore.Extensions
         /// Adds the azure application configuration.
         /// </summary>
         /// <param name="config">The configuration.</param>
-        /// <param name="hostingContext">The hosting context.</param>
+        /// <param name="environmentName">Environment name.</param>
         /// <remarks>
         /// Configuration should contain attributes AppConfig:Endpoint and AppConfig:Settings.
         /// </remarks>
         public static IConfigurationBuilder AddAzureAppConfiguration(
-            this IConfigurationBuilder config,
-            HostBuilderContext hostingContext)
+            this IConfigurationBuilder config, string environmentName)
         {
             var settings = config.Build();
 
@@ -54,7 +53,7 @@ namespace Kros.AspNetCore.Extensions
                 {
                     options
                         .Select($"{service}:*", LabelFilter.Null)
-                        .Select($"{service}:*", hostingContext.HostingEnvironment.EnvironmentName)
+                        .Select($"{service}:*", environmentName)
                         .TrimKeyPrefix($"{service}:");
                 }
 
@@ -63,12 +62,27 @@ namespace Kros.AspNetCore.Extensions
                 {
                     options
                         .Select("_", LabelFilter.Null)
-                        .Select("_", hostingContext.HostingEnvironment.EnvironmentName)
+                        .Select("_", environmentName)
                         .UseFeatureFlags();
                 }
             });
 
             return config;
+        }
+
+        /// <summary>
+        /// Adds the azure application configuration.
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <param name="hostingContext">The hosting context.</param>
+        /// <remarks>
+        /// Configuration should contain attributes AppConfig:Endpoint and AppConfig:Settings.
+        /// </remarks>
+        public static IConfigurationBuilder AddAzureAppConfiguration(
+            this IConfigurationBuilder config,
+            HostBuilderContext hostingContext)
+        {
+            return config.AddAzureAppConfiguration(hostingContext.HostingEnvironment.EnvironmentName);
         }
     }
 }

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -81,5 +81,27 @@ namespace Kros.AspNetCore.Extensions
         public static IConfigurationBuilder AddAzureAppConfiguration(
             this IConfigurationBuilder config,
             HostBuilderContext hostingContext) => config.AddAzureAppConfig(hostingContext.HostingEnvironment.EnvironmentName);
+
+        /// <summary>
+        /// Adds the azure application configuration if AppConfig:Endpoint is defined.
+        /// Does not throw exception if AppConfig:Endpoint is not defined.
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <param name="environmentName">Environment name.</param>
+        /// <remarks>
+        /// Configuration should contain attributes AppConfig:Endpoint and AppConfig:Settings.
+        /// </remarks>
+        public static IConfigurationBuilder AddAzureAppConfigurationIfEndpointDefined(
+            this IConfigurationBuilder config,
+            string environmentName)
+        {
+            var settings = config.Build();
+            string appConfigEndpoint = settings["AppConfig:Endpoint"];
+            if (!string.IsNullOrWhiteSpace(appConfigEndpoint))
+            {
+                config.AddAzureAppConfig(environmentName);
+            }
+            return config;
+        }
     }
 }

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>2.12.0</Version>
+    <Version>2.13.0</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>

--- a/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
@@ -13,27 +13,21 @@ namespace Kros.AspNetCore.Tests.Extensions
         [Fact]
         public void AddAzureAppConfigurationSource()
         {
-            // arrange
             IConfigurationBuilder config = new ConfigurationBuilder();
             HostBuilderContext builderContext = CreateHostBuilderContext();
 
-            // act
             config.AddAzureAppConfiguration(builderContext);
 
-            // assert
             config.Sources.Count.Should().Be(1);
         }
 
         [Fact]
         public void AddAzureAppConfigurationSource2()
         {
-            // arrange
             IConfigurationBuilder config = new ConfigurationBuilder();
 
-            // act
             config.AddAzureAppConfig("Development");
 
-            // assert
             config.Sources.Count.Should().Be(1);
         }
 

--- a/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
@@ -11,24 +11,29 @@ namespace Kros.AspNetCore.Tests.Extensions
     public class ConfigurationBuilderExtensionsShould
     {
         [Fact]
-        public void AddAzureAppConfigurationSource()
+        public void AddAzureAppConfigurationSourceIfEndpointDefined1()
+        {
+            IConfigurationBuilder config = new ConfigurationBuilder();
+            HostBuilderContext builderContext = CreateHostBuilderContext();
+            config.AddInMemoryCollection(
+                new List<KeyValuePair<string, string>>() {
+                    new KeyValuePair<string, string>("AppConfig:Endpoint", "endpoint")
+                });
+
+            config.AddAzureAppConfiguration(builderContext);
+
+            config.Sources.Count.Should().Be(2);
+        }
+
+        [Fact]
+        public void NotAddAzureAppConfigurationSourceIfEndpointNotDefined1()
         {
             IConfigurationBuilder config = new ConfigurationBuilder();
             HostBuilderContext builderContext = CreateHostBuilderContext();
 
             config.AddAzureAppConfiguration(builderContext);
 
-            config.Sources.Count.Should().Be(1);
-        }
-
-        [Fact]
-        public void AddAzureAppConfigurationSource2()
-        {
-            IConfigurationBuilder config = new ConfigurationBuilder();
-
-            config.AddAzureAppConfig("Development");
-
-            config.Sources.Count.Should().Be(1);
+            config.Sources.Count.Should().Be(0);
         }
 
         [Fact]
@@ -40,7 +45,7 @@ namespace Kros.AspNetCore.Tests.Extensions
                     new KeyValuePair<string, string>("AppConfig:Endpoint", "endpoint")
                 });
 
-            config.AddAzureAppConfigurationIfEndpointDefined("Development");
+            config.AddAzureAppConfig("Development");
 
             config.Sources.Count.Should().Be(2);
         }
@@ -49,14 +54,10 @@ namespace Kros.AspNetCore.Tests.Extensions
         public void NotAddAzureAppConfigurationSourceIfEndpointNotDefined()
         {
             IConfigurationBuilder config = new ConfigurationBuilder();
-            config.AddInMemoryCollection(
-                new List<KeyValuePair<string, string>>() {
-                    new KeyValuePair<string, string>("AppConfig:Endpoint", "")
-                });
 
-            config.AddAzureAppConfigurationIfEndpointDefined("Development");
+            config.AddAzureAppConfig("Development");
 
-            config.Sources.Count.Should().Be(1);
+            config.Sources.Count.Should().Be(0);
         }
 
         private HostBuilderContext CreateHostBuilderContext()

--- a/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
@@ -31,6 +31,34 @@ namespace Kros.AspNetCore.Tests.Extensions
             config.Sources.Count.Should().Be(1);
         }
 
+        [Fact]
+        public void AddAzureAppConfigurationSourceIfEndpointDefined()
+        {
+            IConfigurationBuilder config = new ConfigurationBuilder();
+            config.AddInMemoryCollection(
+                new List<KeyValuePair<string, string>>() {
+                    new KeyValuePair<string, string>("AppConfig:Endpoint", "endpoint")
+                });
+
+            config.AddAzureAppConfigurationIfEndpointDefined("Development");
+
+            config.Sources.Count.Should().Be(2);
+        }
+
+        [Fact]
+        public void NotAddAzureAppConfigurationSourceIfEndpointNotDefined()
+        {
+            IConfigurationBuilder config = new ConfigurationBuilder();
+            config.AddInMemoryCollection(
+                new List<KeyValuePair<string, string>>() {
+                    new KeyValuePair<string, string>("AppConfig:Endpoint", "")
+                });
+
+            config.AddAzureAppConfigurationIfEndpointDefined("Development");
+
+            config.Sources.Count.Should().Be(1);
+        }
+
         private HostBuilderContext CreateHostBuilderContext()
         {
             var context = new HostBuilderContext(new Dictionary<object, object>());

--- a/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
@@ -4,13 +4,14 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using System.Collections.Generic;
 using FluentAssertions;
+using NSubstitute;
 
 namespace Kros.AspNetCore.Tests.Extensions
 {
     public class ConfigurationBuilderExtensionsShould
     {
         [Fact]
-        public void AddConfigurationSource()
+        public void AddAzureAppConfigurationSource()
         {
             // arrange
             IConfigurationBuilder config = new ConfigurationBuilder();
@@ -23,10 +24,25 @@ namespace Kros.AspNetCore.Tests.Extensions
             config.Sources.Count.Should().Be(1);
         }
 
+        [Fact]
+        public void AddAzureAppConfigurationSource2()
+        {
+            // arrange
+            IConfigurationBuilder config = new ConfigurationBuilder();
+
+            // act
+            config.AddAzureAppConfig("Development");
+
+            // assert
+            config.Sources.Count.Should().Be(1);
+        }
+
         private HostBuilderContext CreateHostBuilderContext()
         {
             var context = new HostBuilderContext(new Dictionary<object, object>());
             context.Configuration = GetConfiguration();
+            context.HostingEnvironment = Substitute.For<IHostEnvironment>();
+            context.HostingEnvironment.EnvironmentName.Returns("Development");
             return context;
         }
 


### PR DESCRIPTION
Extension to add Azure App Configuration only if appconfig endpoint is defined.
