### PR TITLE
Exception message resending to response

### DIFF
--- a/src/Kros.AspNetCore/Extensions/HttpResponseMessageExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/HttpResponseMessageExtensions.cs
@@ -27,7 +27,7 @@ namespace Kros.AspNetCore.Extensions
                     case System.Net.HttpStatusCode.Unauthorized:
                         throw new UnauthorizedAccessException(Properties.Resources.AuthorizationServiceForbiddenRequest);
                     case System.Net.HttpStatusCode.BadRequest:
-                        throw new BadRequestException();
+                        throw new BadRequestException(response.Content.ReadAsStringAsync().Result);
                     case System.Net.HttpStatusCode.Conflict:
                         throw new RequestConflictException();
                     default:

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>2.17.1</Version>
+    <Version>2.17.2</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>

--- a/src/Kros.AspNetCore/Middlewares/ErrorHandlingMiddleware.cs
+++ b/src/Kros.AspNetCore/Middlewares/ErrorHandlingMiddleware.cs
@@ -81,6 +81,7 @@ namespace Kros.AspNetCore.Middlewares
             {
                 context.Response.ClearExceptCorsHeaders();
                 context.Response.StatusCode = statusCode;
+                context.Response.WriteAsync(ex.Message).Wait();
                 LogStatusCodeChange(ex, statusCode);
             }
             _logger.LogError(ex, ex.Message);

--- a/tests/Kros.AspNetCore.Tests/Extensions/HttpResponseMessageExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Extensions/HttpResponseMessageExtensionsShould.cs
@@ -37,9 +37,13 @@ namespace Kros.AspNetCore.Tests.Extensions
         [Fact]
         public void ThrowsBadRequestExceptionForStatusCode400()
         {
-            var response = new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest };
+            var response = new HttpResponseMessage {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent("Bad request reason")
+            };
+
             Action act = () => response.ThrowIfNotSuccessStatusCode();
-            act.Should().ThrowExactly<BadRequestException>();
+            act.Should().ThrowExactly<BadRequestException>().WithMessage("Bad request reason");
         }
 
         [Fact]


### PR DESCRIPTION
Added writing exception message to response in error handling middleware and added setting exceptin message with response content in httpresponsemessage response check extension.

Creted for resending bad request message, if service is called from another service.