### PR TITLE
Update MassTransit to version 6.3.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,8 @@
     <PackageVersion Include="FluentAssertions" Version="5.10.3" />
     <PackageVersion Include="Kros.Identity.Extensions" Version="0.5.0" />
     <PackageVersion Include="Kros.Utils" Version="1.16.2" />
-    <PackageVersion Include="MassTransit.AspNetCore" Version="6.2.5" />
-    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="6.2.5" />
+    <PackageVersion Include="MassTransit.AspNetCore" Version="6.3.2" />
+    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="6.3.2" />
     <PackageVersion Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="3.1.9" />

--- a/Kros.AspNetCore.sln
+++ b/Kros.AspNetCore.sln
@@ -25,6 +25,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		build-ci.yml = build-ci.yml
 		build.yml = build.yml
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kros.ApplicationInsights.Extensions.Tests", "tests\Kros.ApplicationInsights.Extensions.Tests\Kros.ApplicationInsights.Extensions.Tests.csproj", "{3D90E8DD-C871-4B50-B610-B854E65807F1}"

--- a/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
+++ b/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>1.0.0-alpha.8</Version>
+    <Version>1.0.0-alpha.9</Version>
     <Description>Simpler configuration of MassTransit library.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
@@ -19,7 +19,8 @@ namespace Kros.MassTransit.AzureServiceBus
         #region Attributes
 
         private readonly string _connectionString;
-        private TimeSpan _tokenTimeToLive;
+        private readonly TimeSpan _tokenTimeToLive;
+        private readonly IRegistrationContext<IServiceProvider> _registrationContext;
         private readonly IServiceProvider _provider;
         private readonly string _topicNamePrefix;
         private Action<IServiceBusBusFactoryConfigurator, IServiceBusHost> _busConfigurator;
@@ -70,6 +71,16 @@ namespace Kros.MassTransit.AzureServiceBus
                 : ConfigDefaults.TokenTimeToLive;
             _provider = provider;
             _topicNamePrefix = options.TopicNamePrefix;
+        }
+
+        /// <summary>
+        /// Ctor.
+        /// </summary>
+        /// <param name="registrationContext">MassTransit registration context.</param>
+        public MassTransitForAzureBuilder(IRegistrationContext<IServiceProvider> registrationContext)
+            : this(registrationContext.Container)
+        {
+            _registrationContext = registrationContext;
         }
 
         /// <summary>
@@ -172,9 +183,9 @@ namespace Kros.MassTransit.AzureServiceBus
                 AddMessageTypePrefix(busCfg);
                 AddEndpoints(busCfg);
 
-                if (_provider != null)
+                if (_registrationContext != null)
                 {
-                    busCfg.UseHealthCheck(_provider);
+                    busCfg.UseHealthCheck(_registrationContext);
                 }
             });
 


### PR DESCRIPTION
Už pri riešení SourceLink-u (#107) som upgradol MassTransit z verzie 6.2.4 na 6.2.5 v domnení, že je to len opravná verzia. Zmena v tejto DLL nebola žiadna, ale pri použití vo fakturácii som narazil na spätne nekompatibilné zmeny. MassTransit tam zrušil niekoľko rozhraní a tried kvôli AZ funkciám v3. Na verzii 6.2.5 nemá zmysel ostávať, pretože aj v 6.3.x ešte pár vecí týkajúcich sa tých AZ funkcií upravili a aj [ukážku v dokumentácii](https://masstransit-project.com/usage/transports/azure-sb.html#azure-functions) na svojom webe majú pre verziu 6.3.2.

Takže aktualizujem MassTransit v našej knižnici a následne to aktualizujem a opravím vo fakturácii.