### PR TITLE
Authorization cache

### DIFF
--- a/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
@@ -53,6 +53,14 @@ namespace Kros.AspNetCore.Authorization
         public TimeSpan CacheSlidingExpirationOffset { get; set; } = TimeSpan.Zero;
 
         /// <summary>
+        /// Cache absolute expiration.
+        /// </summary>
+        /// <remarks>
+        /// Default is <see cref="TimeSpan.Zero"/>.
+        /// </remarks>
+        public TimeSpan CacheAbsoluteExpiration { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
         /// Paths that do not use JWT authorization caching.
         /// </summary>
         public List<string> IgnoredPathForCache { get; private set; } = new List<string>();

--- a/src/Kros.AspNetCore/README.md
+++ b/src/Kros.AspNetCore/README.md
@@ -7,9 +7,9 @@
   - [Middlewares](#middlewares)
   - [Extensions](#extensions)
     - [Configuration](#configuration)
-      - [Príklad](#pr%c3%adklad)
+      - [Príklad](#príklad)
     - [ConfigurationBuilderExtensions](#configurationbuilderextensions)
-      - [Príklad](#pr%c3%adklad-1)
+      - [Príklad](#príklad-1)
     - [DistributedCacheExtensions](#distributedcacheextensions)
     - [CorsExtensions](#corsextensions)
   - [BaseStartup](#basestartup)
@@ -296,7 +296,8 @@ Už aj `GatewayAuthorizationMiddleware` podporuje `IServiceDiscoveryProvider`
       "ServiceName": "authorization",
       "PathName": "jwt"
     },
-    "CacheSlidingExpirationOffset": "00:00:00",
+    "CacheSlidingExpirationOffset": "00:01:00",
+    "CacheAbsoluteExpiration": "00:04:00",
     "IgnoredPathForCache": [
       "/organizations"
     ]


### PR DESCRIPTION
Pridáva možnosť nastaviť pre kešovanie JWT tokenu absolútnu expiráciu. 
Pomocou `CacheAbsoluteExpiration` je možné nastaviť maximálnu dobu expirácie aj pokiaľ je nastavená `CacheSlidingExpirationOffset`.