### PR TITLE
Main

### DIFF
--- a/src/Kros.AspNetCore/Authorization/ApplicationBuilderExtensions.cs
+++ b/src/Kros.AspNetCore/Authorization/ApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using Kros.AspNetCore.Options;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using System;
 
@@ -27,7 +28,7 @@ namespace Kros.AspNetCore.Authorization
             if (option is null)
             {
                 throw new InvalidOperationException(
-                    string.Format(Properties.Resources.GatewayJwtAuthorizationMissingSection,
+                    string.Format(Properties.Resources.OptionMissingSection,
                     Helpers.GetSectionName<GatewayJwtAuthorizationOptions>()));
             }
 
@@ -53,5 +54,30 @@ namespace Kros.AspNetCore.Authorization
         public static IApplicationBuilder UseJwtBearerClaims(
             this IApplicationBuilder app)
             => app.UseMiddleware<JwtBearerClaimsMiddleware>();
+
+        /// <summary>
+        /// Add client credentials authorization middleware to request pipeline.
+        /// </summary>
+        /// <param name="app"><see cref="IApplicationBuilder"/> where middleware is added.</param>
+        /// <param name="configuration">Configuration from which the options are loaded.
+        /// Configuration must contains ClientCredentialsAuthorization section.</param>
+        /// <exception cref="InvalidOperationException">
+        /// When `ClientCredentialsAuthorization` section is missing in configuration.
+        /// </exception>
+        public static IApplicationBuilder UseClientCredentialsAuthorization(
+            this IApplicationBuilder app,
+            IConfiguration configuration)
+        {
+            ClientCredentialsAuthorizationOptions option = configuration.GetSection<ClientCredentialsAuthorizationOptions>();
+
+            if (option is null)
+            {
+                throw new InvalidOperationException(
+                    string.Format(Properties.Resources.OptionMissingSection,
+                    Helpers.GetSectionName<ClientCredentialsAuthorizationOptions>()));
+            }
+
+            return app.UseMiddleware<ClientCredentialsAuthorizationMiddleware>(option);
+        }
     }
 }

--- a/src/Kros.AspNetCore/Authorization/ClientCredentialsAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/ClientCredentialsAuthorizationMiddleware.cs
@@ -7,7 +7,6 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
 using System;
-using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Threading;
@@ -81,8 +80,6 @@ namespace Kros.AspNetCore.Authorization
             Check.NotNullOrWhiteSpace(token, nameof(token));
 
             OpenIdConnectConfiguration discoveryDocument = await configurationManager.GetConfigurationAsync(ct);
-            ICollection<SecurityKey> signingKeys = discoveryDocument.SigningKeys;
-
             var validationParameters = new TokenValidationParameters
             {
                 RequireExpirationTime = true,
@@ -90,7 +87,7 @@ namespace Kros.AspNetCore.Authorization
                 ValidateIssuer = true,
                 ValidIssuer = _authorizationOptions.AuthorityUrl,
                 ValidateIssuerSigningKey = true,
-                IssuerSigningKeys = signingKeys,
+                IssuerSigningKeys = discoveryDocument.SigningKeys,
                 ValidateLifetime = true,
                 ValidAudience = _authorizationOptions.Scope,
                 ClockSkew = _authorizationOptions.ClockSkew

--- a/src/Kros.AspNetCore/Authorization/ClientCredentialsAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/ClientCredentialsAuthorizationMiddleware.cs
@@ -30,8 +30,7 @@ namespace Kros.AspNetCore.Authorization
             _next = Check.NotNull(next, nameof(next));
             _authorizationOptions = Check.NotNull(options, nameof(options));
             Check.NotNullOrWhiteSpace(options.AuthorityUrl, nameof(options.AuthorityUrl));
-            Check.NotNullOrWhiteSpace(options.Scope, nameof(options.AuthorityUrl));
-            Check.NotNull(options.ClockSkew, nameof(options.ClockSkew));
+            Check.NotNullOrWhiteSpace(options.Scope, nameof(options.Scope));
         }
 
         /// <summary>
@@ -58,6 +57,8 @@ namespace Kros.AspNetCore.Authorization
 
         private async Task<bool> IsAccessTokenValid(string accessToken)
         {
+            Check.NotNullOrWhiteSpace(accessToken, nameof(accessToken));
+
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                 _authorizationOptions.AuthorityUrl + "/.well-known/openid-configuration",
                 new OpenIdConnectConfigurationRetriever(),
@@ -73,8 +74,6 @@ namespace Kros.AspNetCore.Authorization
             IConfigurationManager<OpenIdConnectConfiguration> configurationManager,
             CancellationToken ct = default)
         {
-            Check.NotNullOrWhiteSpace(token, nameof(token));
-
             OpenIdConnectConfiguration discoveryDocument = await configurationManager.GetConfigurationAsync(ct);
             var validationParameters = new TokenValidationParameters
             {

--- a/src/Kros.AspNetCore/Authorization/ClientCredentialsAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/ClientCredentialsAuthorizationMiddleware.cs
@@ -18,8 +18,8 @@ namespace Kros.AspNetCore.Authorization
     internal class ClientCredentialsAuthorizationMiddleware
     {
         private readonly RequestDelegate _next;
-
         private readonly ClientCredentialsAuthorizationOptions _authorizationOptions;
+
         /// <summary>
         /// Ctor.
         /// </summary>

--- a/src/Kros.AspNetCore/Authorization/ClientCredentialsAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/ClientCredentialsAuthorizationMiddleware.cs
@@ -1,0 +1,112 @@
+﻿using Kros.AspNetCore.Options;
+using Kros.Utils;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.Net.Http.Headers;
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kros.AspNetCore.Authorization
+{
+    /// <summary>
+    /// Middleware for identity server authorization.
+    /// </summary>
+    internal class ClientCredentialsAuthorizationMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ClientCredentialsAuthorizationOptions _authorizationOptions;
+        /// <summary>
+        /// Ctor.
+        /// </summary>
+        /// <param name="next">Next middleware.</param>
+        /// <param name="options">Client credentials authorization options.</param>
+        public ClientCredentialsAuthorizationMiddleware(RequestDelegate next, ClientCredentialsAuthorizationOptions options)
+        {
+            _next = Check.NotNull(next, nameof(next));
+            _authorizationOptions = Check.NotNull(options, nameof(options));
+            Check.NotNullOrWhiteSpace(options.AuthorityUrl, nameof(options.AuthorityUrl));
+            Check.NotNullOrWhiteSpace(options.Scope, nameof(options.AuthorityUrl));
+            Check.NotNull(options.ClockSkew, nameof(options.ClockSkew));
+        }
+
+        /// <summary>
+        /// HttpContext pipeline processing.
+        /// </summary>
+        /// <param name="httpContext">Http context.</param>
+        public async Task Invoke(HttpContext httpContext)
+        {
+            await ValidateJwtToken(httpContext);
+            await _next(httpContext);
+        }
+
+        private async Task ValidateJwtToken(HttpContext httpContext)
+        {
+            if (httpContext.Request.Headers.TryGetValue(HeaderNames.Authorization, out StringValues value))
+            {
+                if (await IsAccessTokenValid(CleanToken(value)))
+                {
+                    return;
+                }
+            }
+            throw new UnauthorizedAccessException(Properties.Resources.AuthorizationServiceForbiddenRequest);
+        }
+
+        private string CleanToken(string token)
+            => token?.Replace("bearer", "", StringComparison.InvariantCultureIgnoreCase).Trim();
+
+        private async Task<bool> IsAccessTokenValid(string accessToken)
+        {
+            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                _authorizationOptions.AuthorityUrl + "/.well-known/openid-configuration",
+                new OpenIdConnectConfigurationRetriever(),
+                new HttpDocumentRetriever());
+
+            JwtSecurityToken validatedToken = await ValidateToken(accessToken, configurationManager);
+
+            return validatedToken != null;
+        }
+
+        private async Task<JwtSecurityToken> ValidateToken(
+            string token,
+            IConfigurationManager<OpenIdConnectConfiguration> configurationManager,
+            CancellationToken ct = default)
+        {
+            Check.NotNullOrWhiteSpace(token, nameof(token));
+
+            OpenIdConnectConfiguration discoveryDocument = await configurationManager.GetConfigurationAsync(ct);
+            ICollection<SecurityKey> signingKeys = discoveryDocument.SigningKeys;
+
+            var validationParameters = new TokenValidationParameters
+            {
+                RequireExpirationTime = true,
+                RequireSignedTokens = true,
+                ValidateIssuer = true,
+                ValidIssuer = _authorizationOptions.AuthorityUrl,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKeys = signingKeys,
+                ValidateLifetime = true,
+                ValidAudience = _authorizationOptions.Scope,
+                ClockSkew = _authorizationOptions.ClockSkew
+            };
+
+            try
+            {
+                ClaimsPrincipal principal = new JwtSecurityTokenHandler()
+                    .ValidateToken(token, validationParameters, out SecurityToken rawValidatedToken);
+
+                return (JwtSecurityToken)rawValidatedToken;
+            }
+            catch (SecurityTokenValidationException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
@@ -72,7 +72,7 @@ namespace Kros.AspNetCore.Authorization
             IMemoryCache memoryCache,
             IServiceDiscoveryProvider serviceDiscoveryProvider)
         {
-            if (httpContext.Request.Headers.TryGetValue(HeaderNames.Authorization, out StringValues value))
+            if (JwtAuthorizationHelper.TryGetTokenValue(httpContext.Request.Headers, out string value))
             {
                 int key = GetKey(httpContext, value);
 
@@ -185,8 +185,6 @@ namespace Kros.AspNetCore.Authorization
             => HashCode.Combine(value, httpContext.Request.Path);
 
         private void AddUserProfileClaimsToIdentityAndHttpHeaders(HttpContext httpContext, string userJwtToken)
-        {
-            httpContext.Request.Headers[HeaderNames.Authorization] = $"Bearer {userJwtToken}";
-        }
+            => httpContext.Request.Headers[HeaderNames.Authorization] = $"{JwtAuthorizationHelper.AuthTokenPrefix} {userJwtToken}";
     }
 }

--- a/src/Kros.AspNetCore/Authorization/JwtAuthorizationHelper.cs
+++ b/src/Kros.AspNetCore/Authorization/JwtAuthorizationHelper.cs
@@ -60,7 +60,7 @@ namespace Kros.AspNetCore.Authorization
         }
 
         /// <summary>
-        ///  Gets the token feom header associated with the specified key <see cref="HeaderNames.Authorization"/>.
+        /// Gets the token from header associated with the specified key <see cref="HeaderNames.Authorization"/>.
         /// </summary>
         /// <param name="httpContext">Http context.</param>
         /// <param name="value">When this method returns, the value associated with the token,

--- a/src/Kros.AspNetCore/Authorization/JwtAuthorizationHelper.cs
+++ b/src/Kros.AspNetCore/Authorization/JwtAuthorizationHelper.cs
@@ -62,8 +62,8 @@ namespace Kros.AspNetCore.Authorization
         /// <summary>
         /// Gets the token from header associated with the specified key <see cref="HeaderNames.Authorization"/>.
         /// </summary>
-        /// <param name="httpContext">Http context.</param>
-        /// <param name="value">When this method returns, the value associated with the token,
+        /// <param name="headers">Http headers.</param>
+        /// <param name="tokenValue">When this method returns, the value associated with the token,
         /// if the key is found; otherwise null.</param>
         /// <param name="removePrefix">True if token prefix (Bearer) should be removed, oherwise false.</param>
         /// <returns>True if the header contains an element with the specified key<see cref="HeaderNames.Authorization"/>.

--- a/src/Kros.AspNetCore/Authorization/JwtAuthorizationHelper.cs
+++ b/src/Kros.AspNetCore/Authorization/JwtAuthorizationHelper.cs
@@ -1,7 +1,11 @@
-﻿using Microsoft.IdentityModel.Tokens;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.Net.Http.Headers;
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Security.Claims;
 using System.Text;
 
@@ -28,6 +32,11 @@ namespace Kros.AspNetCore.Authorization
         public const string OAuthSchemeName = "OAuthAuthorization";
 
         /// <summary>
+        /// Authorization token prefix.
+        /// </summary>
+        public static string AuthTokenPrefix = "Bearer";
+
+        /// <summary>
         /// Create signed JWT token.
         /// </summary>
         /// <param name="userClaims">User claims.</param>
@@ -48,6 +57,31 @@ namespace Kros.AspNetCore.Authorization
             SecurityToken securityToken = tokenHandler.CreateToken(tokenDescriptor);
 
             return tokenHandler.WriteToken(securityToken);
+        }
+
+        /// <summary>
+        ///  Gets the token feom header associated with the specified key <see cref="HeaderNames.Authorization"/>.
+        /// </summary>
+        /// <param name="httpContext">Http context.</param>
+        /// <param name="value">When this method returns, the value associated with the token,
+        /// if the key is found; otherwise null.</param>
+        /// <param name="removePrefix">True if token prefix (Bearer) should be removed, oherwise false.</param>
+        /// <returns>True if the header contains an element with the specified key<see cref="HeaderNames.Authorization"/>.
+        /// Otherwise false./returns>
+        public static bool TryGetTokenValue(IHeaderDictionary headers, out string tokenValue, bool removePrefix = false)
+        {
+            if (headers.TryGetValue(HeaderNames.Authorization, out StringValues authHeader))
+            {
+                tokenValue = authHeader.First();
+                if (removePrefix && tokenValue.StartsWith(AuthTokenPrefix))
+                {
+                    tokenValue = tokenValue[(AuthTokenPrefix.Length + 1)..];
+                }
+                return true;
+
+            }
+            tokenValue = null;
+            return false;
         }
     }
 }

--- a/src/Kros.AspNetCore/Authorization/JwtAuthorizationHelper.cs
+++ b/src/Kros.AspNetCore/Authorization/JwtAuthorizationHelper.cs
@@ -78,7 +78,6 @@ namespace Kros.AspNetCore.Authorization
                     tokenValue = tokenValue[(AuthTokenPrefix.Length + 1)..];
                 }
                 return true;
-
             }
             tokenValue = null;
             return false;

--- a/src/Kros.AspNetCore/Authorization/JwtAuthorizationHelper.cs
+++ b/src/Kros.AspNetCore/Authorization/JwtAuthorizationHelper.cs
@@ -34,7 +34,7 @@ namespace Kros.AspNetCore.Authorization
         /// <summary>
         /// Authorization token prefix.
         /// </summary>
-        public static string AuthTokenPrefix = "Bearer";
+        public const string AuthTokenPrefix = "Bearer";
 
         /// <summary>
         /// Create signed JWT token.

--- a/src/Kros.AspNetCore/Options/ClientCredentialsAuthorizationOptions.cs
+++ b/src/Kros.AspNetCore/Options/ClientCredentialsAuthorizationOptions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Kros.AspNetCore.Options
+{
+    /// <summary>
+    /// Option for client credentials authorization middleware.
+    /// </summary>
+    public class ClientCredentialsAuthorizationOptions
+    {
+        /// <summary>
+        /// Identity server url.
+        /// </summary>
+        public string AuthorityUrl { get; set; }
+
+        /// <summary>
+        /// Identity scope.
+        /// </summary>
+        public string Scope { get; set; }
+
+        /// <summary>
+        /// Clock skew to apply when validating a time.
+        /// </summary>
+        public TimeSpan ClockSkew { get; set; }
+    }
+}

--- a/src/Kros.AspNetCore/Properties/Resources.Designer.cs
+++ b/src/Kros.AspNetCore/Properties/Resources.Designer.cs
@@ -97,15 +97,6 @@ namespace Kros.AspNetCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; configuration section is missing or empty..
-        /// </summary>
-        internal static string GatewayJwtAuthorizationMissingSection {
-            get {
-                return ResourceManager.GetString("GatewayJwtAuthorizationMissingSection", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to  IdentityServer handler for scheme {0}.
         /// </summary>
         internal static string IdentityHealthCheckBuilderName {
@@ -120,6 +111,15 @@ namespace Kros.AspNetCore.Properties {
         internal static string NotFound {
             get {
                 return ResourceManager.GetString("NotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; configuration section is missing or empty..
+        /// </summary>
+        internal static string OptionMissingSection {
+            get {
+                return ResourceManager.GetString("OptionMissingSection", resourceCulture);
             }
         }
         

--- a/src/Kros.AspNetCore/Properties/Resources.resx
+++ b/src/Kros.AspNetCore/Properties/Resources.resx
@@ -131,15 +131,15 @@
     <comment>0 - Full type name of exception.
 1 - New status code for response (number).</comment>
   </data>
-  <data name="GatewayJwtAuthorizationMissingSection" xml:space="preserve">
-    <value>'{0}' configuration section is missing or empty.</value>
-    <comment>0 - Name of the section.</comment>
-  </data>
   <data name="IdentityHealthCheckBuilderName" xml:space="preserve">
     <value> IdentityServer handler for scheme {0}</value>
   </data>
   <data name="NotFound" xml:space="preserve">
     <value>Resource was not found.</value>
+  </data>
+  <data name="OptionMissingSection" xml:space="preserve">
+    <value>'{0}' configuration section is missing or empty.</value>
+    <comment>0 - Name of the section.</comment>
   </data>
   <data name="PathDefinitionDoesntExist" xml:space="preserve">
     <value>Service '{0}' does not have definition for path '{1}'.</value>

--- a/tests/Kros.AspNetCore.Tests/Authorization/ClientCredentialsAuthorizationMiddlewareShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/ClientCredentialsAuthorizationMiddlewareShould.cs
@@ -1,0 +1,49 @@
+﻿using FluentAssertions;
+using Kros.AspNetCore.Authorization;
+using Kros.AspNetCore.Options;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kros.AspNetCore.Tests.Authorization
+{
+    public class ClientCredentialsAuthorizationMiddlewareShould
+    {
+        [Fact]
+        public void ThrowUnauthorizedAccessExceptionOnNonAuthHeader()
+        {
+            HttpContext context = CreateHttpContext();
+            ClientCredentialsAuthorizationMiddleware middleware = CreateMiddleware();
+            Func<Task> funcInvoke = async () => await middleware.Invoke(context);
+            funcInvoke.Should().Throw<UnauthorizedAccessException>();
+        }
+
+        [Theory]
+        [InlineData("NonBearerToken")]
+        [InlineData("Bearer NonJwtToken")]
+        public void ThrowExceptionOnBadAuthHeader(string authHeader)
+        {
+            HttpContext context = CreateHttpContext(authHeader);
+            ClientCredentialsAuthorizationMiddleware middleware = CreateMiddleware();
+            Func<Task> funcInvoke = async () => await middleware.Invoke(context);
+            funcInvoke.Should().Throw<Exception>();
+        }
+
+        private ClientCredentialsAuthorizationMiddleware CreateMiddleware()
+           => new ClientCredentialsAuthorizationMiddleware(
+               (c) => Task.CompletedTask,
+               new ClientCredentialsAuthorizationOptions { AuthorityUrl = "http://any.com", Scope = "123"});
+
+        private HttpContext CreateHttpContext(string authHeader = null)
+        {
+            HttpContext context = new DefaultHttpContext();
+            if (authHeader != null)
+            {
+                context.Request.Headers.Add(HeaderNames.Authorization, authHeader);
+            }
+            return context;
+        }
+    }
+}

--- a/tests/Kros.AspNetCore.Tests/Authorization/JwtAuthorizationHelperShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/JwtAuthorizationHelperShould.cs
@@ -1,5 +1,7 @@
 ﻿using FluentAssertions;
 using Kros.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
@@ -39,6 +41,36 @@ namespace Kros.AspNetCore.Tests.Authorization
                 .CreateJwtTokenFromClaims(claims2, "top_secreat_password", new DateTime(2200, 1, 1));
 
             jwt1.Should().NotBe(jwt2);
+        }
+
+        [Fact]
+        public void TryGetTokenValueReturnsNullToken()
+        {
+            IHeaderDictionary headers = new HeaderDictionary();
+            bool contains = JwtAuthorizationHelper.TryGetTokenValue(headers, out string token);
+
+            contains.Should().BeFalse();
+            token.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("", false, true, "")]
+        [InlineData("123", false, true, "123")]
+        [InlineData("Bearer 123", false, true, "Bearer 123")]
+        [InlineData("", true, true, "")]
+        [InlineData("123", true, true, "123")]
+        [InlineData("Bearer 123", true, true, "123")]
+        public void TryGetTokenValueReturnsCorrectToken(
+            string token,
+            bool removePrefix,
+            bool expectedContains,
+            string expectedToken)
+        {
+            IHeaderDictionary headers = new HeaderDictionary();
+            headers.Add(HeaderNames.Authorization, token);
+            bool contains = JwtAuthorizationHelper.TryGetTokenValue(headers, out token, removePrefix);
+            contains.Should().Be(expectedContains);
+            token.Should().Be(expectedToken);
         }
 
         private IEnumerable<Claim> CreateClaims(int userId, string userEmail)


### PR DESCRIPTION
Closes #128 

Added Kros.AspNetCore.Authorization.ClientCredentialsAuthorizationMiddleware.
Middleware can be used for authentication with client credentials (machine to machine).
Verifies that the jwt token from header is valid on indentity server and contians requered scope.