### PR TITLE
Exclude signalr and options requests

### DIFF
--- a/src/Kros.ApplicationInsights.Extensions/FilterRequestsProcessor.cs
+++ b/src/Kros.ApplicationInsights.Extensions/FilterRequestsProcessor.cs
@@ -48,7 +48,7 @@ namespace Kros.ApplicationInsights.Extensions
                 string userAgent = GetUserAgentName(request);
 
                 if (IsHttpOptions(request)
-                    || _skippedRequests.Any(x => request.Name.Contains(x))
+                    || _skippedRequests.Any(x => request.Name.Contains(x, StringComparison.InvariantCultureIgnoreCase))
                     || _skippedAgents.Any(a => userAgent.Contains(a, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     return;

--- a/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
+++ b/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>1.7.0</Version>
+    <Version>1.8.0</Version>
     <Description>Extensions to facilitate work with Application Insights.</Description>
   </PropertyGroup>
 

--- a/tests/Kros.ApplicationInsights.Extensions.Tests/FilterRequestsProcessorShould.cs
+++ b/tests/Kros.ApplicationInsights.Extensions.Tests/FilterRequestsProcessorShould.cs
@@ -8,6 +8,11 @@ namespace Kros.ApplicationInsights.Extensions.Tests
     {
         [Theory]
         [InlineData("/health", "")]
+        [InlineData("/signalR", "")]
+        [InlineData("OPTIONS/", "")]
+        [InlineData("OPTIONS/someRequest", "")]
+        [InlineData("GET/someRequest", "TestPassed")]
+        [InlineData("GET/optionsrequest", "TestPassed")]
         [InlineData("someRequests", "TestPassed")]
         public void ReturnCorrectSequenceForRequestName(string name, string expectedSequence)
         {


### PR DESCRIPTION
Z pohľadu monitorovania nás nezaujímajú requesty na `/signalR`. Sú to requesty na inicializovanie SignalR spojenia, ... (exceptions sa samozrejme zalogujú).

Taktiež nepotrebujeme logovať `options` requesty. 

>`RequestTelemetry` má property `HttpMethod`, ale je depricated a podľa dokumentácie sa http metóda nachádza len v názve danej telemetrie.