### PR TITLE
Set defaults for endpoints.

### DIFF
--- a/src/Kros.MassTransit.AzureServiceBus/ConfigDefaults.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/ConfigDefaults.cs
@@ -15,7 +15,7 @@ namespace Kros.MassTransit.AzureServiceBus
         /// <summary>
         /// Default message time to live in the queue.
         /// </summary>
-        public static readonly TimeSpan MessageTimeToLive = TimeSpan.FromMinutes(3);
+        public static readonly TimeSpan MessageTimeToLive = TimeSpan.FromDays(14);
 
         /// <summary>
         /// Default setting for move messages to the dead letter queue on expiration (time to live exceeded).
@@ -25,12 +25,12 @@ namespace Kros.MassTransit.AzureServiceBus
         /// <summary>
         /// Default lock duration for messages read from the queue.
         /// </summary>
-        public static readonly TimeSpan LockDuration = TimeSpan.FromSeconds(30);
+        public static readonly TimeSpan LockDuration = TimeSpan.FromMinutes(1);
 
         /// <summary>
         /// Default value for if the queue should be deleted if idle.
         /// </summary>
-        public static readonly TimeSpan AutoDeleteOnIdle = TimeSpan.FromMinutes(10);
+        public static readonly TimeSpan AutoDeleteOnIdle = TimeSpan.FromDays(14);
 
         /// <summary>
         /// Default maximum delivery count. A message is automatically deadlettered after this number of deliveries.

--- a/src/Kros.MassTransit.AzureServiceBus/Endpoints/Endpoint.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/Endpoints/Endpoint.cs
@@ -55,5 +55,18 @@ namespace Kros.MassTransit.AzureServiceBus.Endpoints
         /// </summary>
         /// <param name="busCfg">Service bus configuration.</param>
         public abstract void SetEndpoint(IServiceBusBusFactoryConfigurator busCfg);
+
+        /// <summary>
+        /// Sets endpoint defaults.
+        /// </summary>
+        /// <param name="configurator">Endpoint configurator.</param>
+        protected void SetDefaults(IServiceBusEndpointConfigurator configurator)
+        {
+            configurator.DefaultMessageTimeToLive = ConfigDefaults.MessageTimeToLive;
+            configurator.EnableDeadLetteringOnMessageExpiration = ConfigDefaults.EnableDeadLetteringOnMessageExpiration;
+            configurator.LockDuration = ConfigDefaults.LockDuration;
+            configurator.AutoDeleteOnIdle = ConfigDefaults.AutoDeleteOnIdle;
+            configurator.MaxDeliveryCount = ConfigDefaults.MaxDeliveryCount;
+        }
     }
 }

--- a/src/Kros.MassTransit.AzureServiceBus/Endpoints/ReceiveEndpoint.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/Endpoints/ReceiveEndpoint.cs
@@ -44,6 +44,9 @@ namespace Kros.MassTransit.AzureServiceBus.Endpoints
         public override void SetEndpoint(IServiceBusBusFactoryConfigurator busCfg)
             => busCfg.ReceiveEndpoint(Name, endpointConfig =>
             {
+                SetDefaults(endpointConfig);
+                endpointConfig.DuplicateDetectionHistoryTimeWindow = ConfigDefaults.DuplicateDetectionWindow;
+
                 _configurator?.Invoke(endpointConfig);
 
                 foreach (Action<IServiceBusReceiveEndpointConfigurator> consumerConfig in _consumers)

--- a/src/Kros.MassTransit.AzureServiceBus/Endpoints/SubscriptionEndpoint.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/Endpoints/SubscriptionEndpoint.cs
@@ -44,6 +44,8 @@ namespace Kros.MassTransit.AzureServiceBus.Endpoints
         public override void SetEndpoint(IServiceBusBusFactoryConfigurator busCfg)
             => busCfg.SubscriptionEndpoint<TMessage>(Name, endpointConfig =>
             {
+                SetDefaults(endpointConfig);
+
                 _configurator?.Invoke(endpointConfig);
 
                 foreach (Action<IServiceBusSubscriptionEndpointConfigurator> consumerConfig in _consumers)

--- a/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
+++ b/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Description>Simpler configuration of MassTransit library.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>


### PR DESCRIPTION
Updated defaults for ASB to 14 days for message TTL, 1 minute for lock duration and 14 days for auto delete on idle.
These defaults are applied when creating endpoints and can be overriden via config action.