### PR TITLE
Add support for cache preflight requests

### DIFF
--- a/src/Kros.AspNetCore/Extensions/CorsExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/CorsExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 
@@ -21,27 +20,20 @@ namespace Kros.AspNetCore.Extensions
             long preflightMaxAgeInMinutes = 60)
             => services.AddCors(options =>
             {
-                if (preflightMaxAgeInMinutes <= 0)
-                {
-                    options.AddPolicy(
-                        AllowAnyOrigins,
-                        builder => builder
+                options.AddPolicy(
+                    AllowAnyOrigins,
+                    builder => {
+                        builder
                             .SetIsOriginAllowed(origin => true)
                             .AllowAnyMethod()
                             .AllowAnyHeader()
-                            .AllowCredentials());
-                }
-                else
-                {
-                    options.AddPolicy(
-                        AllowAnyOrigins,
-                        builder => builder
-                            .SetIsOriginAllowed(origin => true)
-                            .AllowAnyMethod()
-                            .AllowAnyHeader()
-                            .AllowCredentials()
-                            .SetPreflightMaxAge(TimeSpan.FromMinutes(preflightMaxAgeInMinutes)));
-                }
+                            .AllowCredentials();
+
+                        if (preflightMaxAgeInMinutes <= 0)
+                        {
+                            builder.SetPreflightMaxAge(TimeSpan.FromMinutes(preflightMaxAgeInMinutes));
+                        }
+                    });
             });
 
         /// <summary>
@@ -55,28 +47,22 @@ namespace Kros.AspNetCore.Extensions
             this IServiceCollection services,
             string[] allowedOrigins,
             string policyName,
-            long preflightMaxAgeInMinutes = TimeSpan.TicksPerHour)
+            int preflightMaxAgeInMinutes = 60)
             => services.AddCors(options =>
             {
-                if (preflightMaxAgeInMinutes <= 0)
-                {
-                    options.AddPolicy(
+                options.AddPolicy(
                     policyName,
-                    builder => builder
-                        .WithOrigins(allowedOrigins)
-                        .AllowAnyMethod()
-                        .AllowAnyHeader());
-                }
-                else
-                {
-                    options.AddPolicy(
-                    policyName,
-                    builder => builder
-                        .WithOrigins(allowedOrigins)
-                        .AllowAnyMethod()
-                        .AllowAnyHeader()
-                        .SetPreflightMaxAge(TimeSpan.FromMinutes(preflightMaxAgeInMinutes)));
-                }
+                    builder => {
+                        builder
+                            .WithOrigins(allowedOrigins)
+                            .AllowAnyMethod()
+                            .AllowAnyHeader();
+
+                        if (preflightMaxAgeInMinutes <= 0)
+                        {
+                            builder.SetPreflightMaxAge(TimeSpan.FromMinutes(preflightMaxAgeInMinutes));
+                        }
+                    });
             });
 
         /// <summary>

--- a/src/Kros.AspNetCore/Extensions/CorsExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/CorsExtensions.cs
@@ -17,7 +17,7 @@ namespace Kros.AspNetCore.Extensions
         /// <param name="services">IoC container.</param>
         /// <param name="preflightMaxAgeInMinutes">Cache preflight requests in ticks. Default is 60 minutes.</param>
         public static IServiceCollection AddAllowAnyOriginCors(this IServiceCollection services,
-            long preflightMaxAgeInMinutes = 60)
+            int preflightMaxAgeInMinutes = 60)
             => services.AddCors(options =>
             {
                 options.AddPolicy(

--- a/src/Kros.AspNetCore/Extensions/CorsExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/CorsExtensions.cs
@@ -16,12 +16,12 @@ namespace Kros.AspNetCore.Extensions
         /// Adds allow all origins Cors policy.
         /// </summary>
         /// <param name="services">IoC container.</param>
-        /// <param name="preflightMaxAge">Cache preflight requests in ticks. Default is <see cref="TimeSpan.TicksPerHour"/>.</param>
+        /// <param name="preflightMaxAgeInMinutes">Cache preflight requests in ticks. Default is 60 minutes.</param>
         public static IServiceCollection AddAllowAnyOriginCors(this IServiceCollection services,
-            long preflightMaxAge = TimeSpan.TicksPerHour)
+            long preflightMaxAgeInMinutes = 60)
             => services.AddCors(options =>
             {
-                if (preflightMaxAge <= 0)
+                if (preflightMaxAgeInMinutes <= 0)
                 {
                     options.AddPolicy(
                         AllowAnyOrigins,
@@ -40,7 +40,7 @@ namespace Kros.AspNetCore.Extensions
                             .AllowAnyMethod()
                             .AllowAnyHeader()
                             .AllowCredentials()
-                            .SetPreflightMaxAge(TimeSpan.FromTicks(preflightMaxAge)));
+                            .SetPreflightMaxAge(TimeSpan.FromMinutes(preflightMaxAgeInMinutes)));
                 }
             });
 
@@ -50,15 +50,15 @@ namespace Kros.AspNetCore.Extensions
         /// <param name="services">IoC container.</param>
         /// <param name="allowedOrigins">List of allowed origins.</param>
         /// <param name="policyName">Name of custom cors policy.</param>
-        /// <param name="preflightMaxAge">Cache preflight requests in ticks. Default is <see cref="TimeSpan.TicksPerHour"/>.</param>
+        /// <param name="preflightMaxAgeInMinutes">Cache preflight requests in ticks. Default is 60 minutes.</param>
         public static IServiceCollection AddCustomOriginsCorsPolicy(
             this IServiceCollection services,
             string[] allowedOrigins,
             string policyName,
-            long preflightMaxAge = TimeSpan.TicksPerHour)
+            long preflightMaxAgeInMinutes = TimeSpan.TicksPerHour)
             => services.AddCors(options =>
             {
-                if (preflightMaxAge <= 0)
+                if (preflightMaxAgeInMinutes <= 0)
                 {
                     options.AddPolicy(
                     policyName,
@@ -75,7 +75,7 @@ namespace Kros.AspNetCore.Extensions
                         .WithOrigins(allowedOrigins)
                         .AllowAnyMethod()
                         .AllowAnyHeader()
-                        .SetPreflightMaxAge(TimeSpan.FromTicks(preflightMaxAge)));
+                        .SetPreflightMaxAge(TimeSpan.FromMinutes(preflightMaxAgeInMinutes)));
                 }
             });
 

--- a/src/Kros.AspNetCore/Extensions/CorsExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/CorsExtensions.cs
@@ -12,12 +12,19 @@ namespace Kros.AspNetCore.Extensions
         private const string AllowAnyOrigins = "AllowAnyOrigins";
 
         /// <summary>
-        /// Adds allow all origins Cors policy.
+        /// Adds allow all origins Cors policy with caching preflights requests with default value (1 hour).
         /// </summary>
         /// <param name="services">IoC container.</param>
-        /// <param name="preflightMaxAgeInMinutes">Cache preflight requests in ticks. Default is 60 minutes.</param>
+        public static IServiceCollection AddAllowAnyOriginCors(this IServiceCollection services)
+            => AddAllowAnyOriginCors(services, 60);
+
+        /// <summary>
+        /// Adds allow all origins Cors policy with caching preflight requests with defined value.
+        /// </summary>
+        /// <param name="services">IoC container.</param>
+        /// <param name="preflightMaxAgeInMinutes">Cache preflight requests in minutes.</param>
         public static IServiceCollection AddAllowAnyOriginCors(this IServiceCollection services,
-            int preflightMaxAgeInMinutes = 60)
+            int preflightMaxAgeInMinutes)
             => services.AddCors(options =>
             {
                 options.AddPolicy(
@@ -37,17 +44,29 @@ namespace Kros.AspNetCore.Extensions
             });
 
         /// <summary>
-        /// Adds custom Cors policy.
+        /// Adds custom Cors policy with caching preflights requests with default value (1 hour).
         /// </summary>
         /// <param name="services">IoC container.</param>
         /// <param name="allowedOrigins">List of allowed origins.</param>
         /// <param name="policyName">Name of custom cors policy.</param>
-        /// <param name="preflightMaxAgeInMinutes">Cache preflight requests in ticks. Default is 60 minutes.</param>
+        public static IServiceCollection AddCustomOriginsCorsPolicy(
+            this IServiceCollection services,
+            string[] allowedOrigins,
+            string policyName)
+            => AddCustomOriginsCorsPolicy(services, allowedOrigins, policyName, 60);
+
+        /// <summary>
+        /// Adds custom Cors policy with caching preflight requests with defined value.
+        /// </summary>
+        /// <param name="services">IoC container.</param>
+        /// <param name="allowedOrigins">List of allowed origins.</param>
+        /// <param name="policyName">Name of custom cors policy.</param>
+        /// <param name="preflightMaxAgeInMinutes">Cache preflight requests in ticks.</param>
         public static IServiceCollection AddCustomOriginsCorsPolicy(
             this IServiceCollection services,
             string[] allowedOrigins,
             string policyName,
-            int preflightMaxAgeInMinutes = 60)
+            int preflightMaxAgeInMinutes)
             => services.AddCors(options =>
             {
                 options.AddPolicy(

--- a/src/Kros.AspNetCore/Extensions/CorsExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/CorsExtensions.cs
@@ -16,15 +16,15 @@ namespace Kros.AspNetCore.Extensions
         /// </summary>
         /// <param name="services">IoC container.</param>
         public static IServiceCollection AddAllowAnyOriginCors(this IServiceCollection services)
-            => AddAllowAnyOriginCors(services, 60);
+            => AddAllowAnyOriginCors(services, TimeSpan.FromHours(1));
 
         /// <summary>
-        /// Adds allow all origins Cors policy with caching preflight requests with defined value.
+        /// Adds allow all origins Cors policy with caching preflight requests with defined time.
         /// </summary>
         /// <param name="services">IoC container.</param>
-        /// <param name="preflightMaxAgeInMinutes">Cache preflight requests in minutes.</param>
+        /// <param name="preflightMaxAge">Indicating the time a preflight request can be cached.</param>
         public static IServiceCollection AddAllowAnyOriginCors(this IServiceCollection services,
-            int preflightMaxAgeInMinutes)
+            TimeSpan preflightMaxAge)
             => services.AddCors(options =>
             {
                 options.AddPolicy(
@@ -36,9 +36,9 @@ namespace Kros.AspNetCore.Extensions
                             .AllowAnyHeader()
                             .AllowCredentials();
 
-                        if (preflightMaxAgeInMinutes <= 0)
+                        if (preflightMaxAge > TimeSpan.Zero)
                         {
-                            builder.SetPreflightMaxAge(TimeSpan.FromMinutes(preflightMaxAgeInMinutes));
+                            builder.SetPreflightMaxAge(preflightMaxAge);
                         }
                     });
             });
@@ -53,20 +53,20 @@ namespace Kros.AspNetCore.Extensions
             this IServiceCollection services,
             string[] allowedOrigins,
             string policyName)
-            => AddCustomOriginsCorsPolicy(services, allowedOrigins, policyName, 60);
+            => AddCustomOriginsCorsPolicy(services, allowedOrigins, policyName, TimeSpan.FromHours(1));
 
         /// <summary>
-        /// Adds custom Cors policy with caching preflight requests with defined value.
+        /// Adds custom Cors policy with caching preflight requests with defined time.
         /// </summary>
         /// <param name="services">IoC container.</param>
         /// <param name="allowedOrigins">List of allowed origins.</param>
         /// <param name="policyName">Name of custom cors policy.</param>
-        /// <param name="preflightMaxAgeInMinutes">Cache preflight requests in ticks.</param>
+        /// <param name="preflightMaxAge">Indicating the time a preflight request can be cached.</param>
         public static IServiceCollection AddCustomOriginsCorsPolicy(
             this IServiceCollection services,
             string[] allowedOrigins,
             string policyName,
-            int preflightMaxAgeInMinutes)
+            TimeSpan preflightMaxAge)
             => services.AddCors(options =>
             {
                 options.AddPolicy(
@@ -77,9 +77,9 @@ namespace Kros.AspNetCore.Extensions
                             .AllowAnyMethod()
                             .AllowAnyHeader();
 
-                        if (preflightMaxAgeInMinutes <= 0)
+                        if (preflightMaxAge > TimeSpan.Zero)
                         {
-                            builder.SetPreflightMaxAge(TimeSpan.FromMinutes(preflightMaxAgeInMinutes));
+                            builder.SetPreflightMaxAge(preflightMaxAge);
                         }
                     });
             });

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>2.29.2</Version>
+    <Version>2.29.3</Version>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/Kros.AspNetCore/README.md
+++ b/src/Kros.AspNetCore/README.md
@@ -140,7 +140,7 @@ var toDo = await _cache.GetAndSetAsync(
 ### CorsExtensions
 
 Obsahuje nastavenie `CORS` policy. Je možné povoliť všetky domény pomocou `AddAllowAnyOriginCors`, alebo povoliť iba vymenované domény pomocou metódy `AddCustomOriginsCorsPolicy`. Tieto domény je potrebné vymenovať v `appsettings.json` v sekcii `AllowedHosts`.
-Obe metódy nastavujú cachovanie preflight requestov (OPTIONS) defaultne na 2 hodiny.
+Obe metódy nastavujú cachovanie preflight requestov (OPTIONS) defaultne na 1 hodinu.
 
 ## BaseStartup
 

--- a/src/Kros.AspNetCore/README.md
+++ b/src/Kros.AspNetCore/README.md
@@ -140,6 +140,7 @@ var toDo = await _cache.GetAndSetAsync(
 ### CorsExtensions
 
 Obsahuje nastavenie `CORS` policy. Je možné povoliť všetky domény pomocou `AddAllowAnyOriginCors`, alebo povoliť iba vymenované domény pomocou metódy `AddCustomOriginsCorsPolicy`. Tieto domény je potrebné vymenovať v `appsettings.json` v sekcii `AllowedHosts`.
+Obe metódy nastavujú cachovanie preflight requestov (OPTIONS) defaultne na 2 hodiny.
 
 ## BaseStartup
 


### PR DESCRIPTION
All preflight requests (OPTIONS) will be cached in browser. Default value for caching is 1 hour.