### PR TITLE
Docker support

### DIFF
--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>2.42.0</Version>
+    <Version>2.43.0</Version>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/Kros.AspNetCore/README.md
+++ b/src/Kros.AspNetCore/README.md
@@ -19,6 +19,7 @@
     - [Custom mapping](#custom-mapping)
   - [Service Discovery Provider](#service-discovery-provider)
     - [Get started](#get-started)
+      - [Allow service name as host](#allow-service-name-as-host)
     - [GatewayAuthorizationMiddleware](#gatewayauthorizationmiddleware)
 
 ## Exceptions
@@ -281,6 +282,42 @@ provider.GetPath(ServiceType.Authorization, "jwt");
 alebo
 ```CSharp
 provider.GetService(ServiceType.Organizations);
+```
+
+#### Allow service name as host
+
+V prípade Docker prostredia je možné využiť situáciu, že služby bežia pod rovnakým portom a názov hostu je znodný s názvom služby. V tomto prípade je potrebné nastaviť vlastnosť `AllowServiceNameAsHost` na `true`.
+
+```csharp
+services.AddServiceDiscovery((o) =>
+{
+    o.AllowServiceNameAsHost = true;
+});
+```
+
+Je možné explicitne definovať `Port` a `Scheme`.
+
+```csharp
+services.AddServiceDiscovery((o) =>
+{
+    o.AllowServiceNameAsHost = true;
+    o.Port = 443;
+    o.Scheme = "https";
+});
+```
+
+> Pokiaľ ich nešpecifikujeme tak sa použije `80` a `http`.
+
+V prípade, že chcete niektorú adresu vynútiť *(nechcete sa aby sa použil názov služby ako host, ale aby sa použila zadaná `DownstreamPath`, tak je potebné zadať vlastnostnosť `Force:true`)*.
+
+```json
+"catalog": {
+    "DownstreamPath": "http://localhost:9004",
+    "force": true,
+    "paths": {
+        "create": "/api/catalog"
+    }
+},
 ```
 
 ### GatewayAuthorizationMiddleware

--- a/src/Kros.AspNetCore/README.md
+++ b/src/Kros.AspNetCore/README.md
@@ -308,12 +308,12 @@ services.AddServiceDiscovery((o) =>
 
 > Pokiaľ ich nešpecifikujeme tak sa použije `80` a `http`.
 
-V prípade, že chcete niektorú adresu vynútiť *(nechcete sa aby sa použil názov služby ako host, ale aby sa použila zadaná `DownstreamPath`, tak je potebné zadať vlastnostnosť `Force:true`)*.
+V prípade, že chcete niektorú adresu vynútiť *(nechcete sa aby sa použil názov služby ako host, ale aby sa použila zadaná `DownstreamPath`, tak je potebné zadať vlastnostnosť `ForceDownstreamPath:true`)*.
 
 ```json
 "catalog": {
     "DownstreamPath": "http://localhost:9004",
-    "force": true,
+    "ForceDownstreamPath": true,
     "paths": {
         "create": "/api/catalog"
     }

--- a/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
+++ b/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
@@ -51,9 +51,11 @@ namespace Kros.AspNetCore.ServiceDiscovery
         /// <inheritdoc />
         public Uri GetService(string serviceName)
         {
-            string uri = _configuration.GetValue<string>($"{_option.SectionName}:{serviceName}:DownstreamPath");
+            string GetSectionKey(string propertyName) => $"{_option.SectionName}:{serviceName}:{propertyName}";
+            string uri = _configuration.GetValue<string>(GetSectionKey("DownstreamPath"));
+            bool force = _configuration.GetValue<bool>(GetSectionKey("Force"));
 
-            if (_option.AllowServiceNameAsHost)
+            if (_option.AllowServiceNameAsHost && !force)
             {
                 return new UriBuilder(_option.Scheme, serviceName, _option.Port).Uri;
             }

--- a/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
+++ b/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
@@ -53,7 +53,7 @@ namespace Kros.AspNetCore.ServiceDiscovery
         {
             string GetSectionKey(string propertyName) => $"{_option.SectionName}:{serviceName}:{propertyName}";
             string uri = _configuration.GetValue<string>(GetSectionKey("DownstreamPath"));
-            bool force = _configuration.GetValue<bool>(GetSectionKey("Force"));
+            bool force = _configuration.GetValue<bool>(GetSectionKey("ForceDownstreamPath"));
 
             if (_option.AllowServiceNameAsHost && !force)
             {

--- a/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
+++ b/src/Kros.AspNetCore/ServiceDiscovery/ServiceDiscoveryProvider.cs
@@ -53,13 +53,13 @@ namespace Kros.AspNetCore.ServiceDiscovery
         {
             string uri = _configuration.GetValue<string>($"{_option.SectionName}:{serviceName}:DownstreamPath");
 
-            if (!uri.IsNullOrEmpty())
-            {
-                return new Uri(uri);
-            }
-            else if (_option.AllowServiceNameAsHost)
+            if (_option.AllowServiceNameAsHost)
             {
                 return new UriBuilder(_option.Scheme, serviceName, _option.Port).Uri;
+            }
+            else if (!uri.IsNullOrEmpty())
+            {
+                return new Uri(uri);
             }
             else
             {

--- a/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
+++ b/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
@@ -25,7 +25,7 @@ namespace Kros.AspNetCore.Tests.ServiceDiscovery
         [InlineData("Users", "getAll", "http://localhost:9003/api/users", false)]
         [InlineData("Users", "getById", "http://localhost:9003/api/users/{id}", false)]
         [InlineData("Projects", "create", "http://localhost:9002/api/projects", false)]
-        [InlineData("Projects", "create", "http://localhost:9002/api/projects", true)]
+        [InlineData("Projects", "create", "http://projects/api/projects", true)]
         public void FindPathUriByServiceAndPathName(string serviceName, string pathName, string expectedUri, bool allowHost)
         {
             var provider = new ServiceDiscoveryProvider(GetConfiguration(), new ServiceDiscoveryOptions()

--- a/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
+++ b/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceDiscoveryShould.cs
@@ -26,6 +26,7 @@ namespace Kros.AspNetCore.Tests.ServiceDiscovery
         [InlineData("Users", "getById", "http://localhost:9003/api/users/{id}", false)]
         [InlineData("Projects", "create", "http://localhost:9002/api/projects", false)]
         [InlineData("Projects", "create", "http://projects/api/projects", true)]
+        [InlineData("Catalog", "create", "http://localhost:9004/api/catalog", true)]
         public void FindPathUriByServiceAndPathName(string serviceName, string pathName, string expectedUri, bool allowHost)
         {
             var provider = new ServiceDiscoveryProvider(GetConfiguration(), new ServiceDiscoveryOptions()

--- a/tests/Kros.AspNetCore.Tests/servicediscoveryAppsettings.json
+++ b/tests/Kros.AspNetCore.Tests/servicediscoveryAppsettings.json
@@ -15,7 +15,7 @@
     },
     "catalog": {
       "DownstreamPath": "http://localhost:9004",
-      "force": true,
+      "ForceDownstreamPath": true,
       "paths": {
         "create": "/api/catalog"
       }

--- a/tests/Kros.AspNetCore.Tests/servicediscoveryAppsettings.json
+++ b/tests/Kros.AspNetCore.Tests/servicediscoveryAppsettings.json
@@ -4,13 +4,20 @@
       "downstreamPath": "http://localhost:9003",
       "paths": {
         "getAll": "/api/users",
-        "getById":  "/api/users/{id}"
+        "getById": "/api/users/{id}"
       }
     },
     "projects": {
       "DownstreamPath": "http://localhost:9002",
       "paths": {
         "create": "/api/projects"
+      }
+    },
+    "catalog": {
+      "DownstreamPath": "http://localhost:9004",
+      "force": true,
+      "paths": {
+        "create": "/api/catalog"
       }
     },
     "Authorization": {


### PR DESCRIPTION
Trochu som prerobil fungovanie nového parametra `AllowServiceNameAsHost `. On sa používa výhradne pre Docker prostredie, problém nastal keď som do daného prostredia pridal aj konfiguráciu z AppConfiguration a tým pádom service discovery nefungoval správne.

### Allow service name as host

V prípade Docker prostredia je možné využiť situáciu, že služby bežia pod rovnakým portom a názov hostu je znodný s názvom služby. V tomto prípade je potrebné nastaviť vlastnosť `AllowServiceNameAsHost` na `true`.

```csharp
services.AddServiceDiscovery((o) =>
{
    o.AllowServiceNameAsHost = true;
});
```

Je možné explicitne definovať `Port` a `Scheme`.

```csharp
services.AddServiceDiscovery((o) =>
{
    o.AllowServiceNameAsHost = true;
    o.Port = 443;
    o.Scheme = "https";
});
```

> Pokiaľ ich nešpecifikujeme tak sa použije `80` a `http`.

V prípade, že chcete niektorú adresu vynútiť *(nechcete sa aby sa použil názov služby ako host, ale aby sa použila zadaná `DownstreamPath`, tak je potebné zadať vlastnostnosť `Force:true`)*.

```json
"catalog": {
    "DownstreamPath": "http://localhost:9004",
    "force": true,
    "paths": {
        "create": "/api/catalog"
    }
},
```