### PR TITLE
Added option for preserving unsuccessful response content in exceptions.

### DIFF
--- a/src/Kros.AspNetCore/Exceptions/PaymentRequiredException.cs
+++ b/src/Kros.AspNetCore/Exceptions/PaymentRequiredException.cs
@@ -1,17 +1,17 @@
-﻿using System;
+﻿using System.Net.Http.Headers;
 
 namespace Kros.AspNetCore.Exceptions
 {
     /// <summary>
     ///  The exception which is thrown when request cannot be completed because of missing payment.
     /// </summary>
-    public class PaymentRequiredException : Exception
+    public class PaymentRequiredException : RequestUnsuccessfulException
     {
         /// <summary>
         /// Initializes a new instance of <see cref="PaymentRequiredException"/> class.
         /// </summary>
         public PaymentRequiredException()
-            : this(Properties.Resources.PaymentRequired)
+            : base(Properties.Resources.PaymentRequired)
         {
         }
 
@@ -21,6 +21,27 @@ namespace Kros.AspNetCore.Exceptions
         /// <param name="message">Message.</param>
         public PaymentRequiredException(string message)
             : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="PaymentRequiredException"/> class.
+        /// </summary>
+        /// <param name="responseContent">Serialized response content.</param>
+        /// <param name="responseContentType">Response content type.</param>
+        public PaymentRequiredException(string responseContent, MediaTypeHeaderValue responseContentType)
+            : base(Properties.Resources.PaymentRequired, responseContent, responseContentType)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="PaymentRequiredException"/> class.
+        /// </summary>
+        /// <param name="message">Message.</param>
+        /// <param name="responseContent">Serialized response content.</param>
+        /// <param name="responseContentType">Response content type.</param>
+        public PaymentRequiredException(string message, string responseContent, MediaTypeHeaderValue responseContentType)
+            : base(message, responseContent, responseContentType)
         {
         }
     }

--- a/src/Kros.AspNetCore/Exceptions/RequestUnsuccessfulException.cs
+++ b/src/Kros.AspNetCore/Exceptions/RequestUnsuccessfulException.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Net.Http.Headers;
+using System.Net.Mime;
+
+namespace Kros.AspNetCore.Exceptions
+{
+    /// <summary>
+    ///  The exception thrown when request was not successful.
+    /// </summary>
+    public class RequestUnsuccessfulException : Exception
+    {
+        /// <summary>
+        /// Response payload content type.
+        /// </summary>
+        public MediaTypeHeaderValue ResponseContentType { get; private set; }
+
+        /// <summary>
+        /// Serialized response content.
+        /// </summary>
+        public string ResponseContent { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="RequestUnsuccessfulException"/> class.
+        /// </summary>
+        public RequestUnsuccessfulException()
+            : this(string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="RequestUnsuccessfulException"/> class.
+        /// </summary>
+        /// <param name="message">Message.</param>
+        public RequestUnsuccessfulException(string message)
+            : this(message, null, new MediaTypeHeaderValue(MediaTypeNames.Text.Plain))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="RequestUnsuccessfulException"/> class.
+        /// </summary>
+        /// <param name="responseContent">Serialized response content.</param>
+        /// <param name="responseContentType">Response content type.</param>
+        public RequestUnsuccessfulException(string responseContent, MediaTypeHeaderValue responseContentType)
+            : this(string.Empty, responseContent, responseContentType)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="RequestUnsuccessfulException"/> class.
+        /// </summary>
+        /// <param name="message">Message.</param>
+        /// <param name="responseContent">Serialized response content.</param>
+        /// <param name="responseContentType">Response content type.</param>
+        public RequestUnsuccessfulException(string message, string responseContent, MediaTypeHeaderValue responseContentType)
+            : base(message)
+        {
+            AddPayload(responseContent, responseContentType);
+        }
+
+        /// <summary>
+        /// Adds payload to exception.
+        /// </summary>
+        /// <param name="payload">Serialized payload.</param>
+        /// <param name="payloadContentType">Payload content type.</param>
+        internal void AddPayload(string payload, MediaTypeHeaderValue payloadContentType)
+        {
+            ResponseContent = payload;
+            ResponseContentType = payloadContentType;
+        }
+    }
+}

--- a/src/Kros.AspNetCore/Exceptions/RequestUnsuccessfulException.cs
+++ b/src/Kros.AspNetCore/Exceptions/RequestUnsuccessfulException.cs
@@ -5,20 +5,10 @@ using System.Net.Mime;
 namespace Kros.AspNetCore.Exceptions
 {
     /// <summary>
-    ///  The exception thrown when request was not successful.
+    /// The exception thrown when request was not successful.
     /// </summary>
     public class RequestUnsuccessfulException : Exception
     {
-        /// <summary>
-        /// Response payload content type.
-        /// </summary>
-        public MediaTypeHeaderValue ResponseContentType { get; private set; }
-
-        /// <summary>
-        /// Serialized response content.
-        /// </summary>
-        public string ResponseContent { get; private set; }
-
         /// <summary>
         /// Initializes a new instance of <see cref="RequestUnsuccessfulException"/> class.
         /// </summary>
@@ -57,6 +47,16 @@ namespace Kros.AspNetCore.Exceptions
         {
             AddPayload(responseContent, responseContentType);
         }
+
+        /// <summary>
+        /// Response payload content type.
+        /// </summary>
+        public MediaTypeHeaderValue ResponseContentType { get; private set; }
+
+        /// <summary>
+        /// Serialized response content.
+        /// </summary>
+        public string ResponseContent { get; private set; }
 
         /// <summary>
         /// Adds payload to exception.

--- a/src/Kros.AspNetCore/Extensions/HttpClientExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/HttpClientExtensions.cs
@@ -24,7 +24,8 @@ namespace Kros.AspNetCore.Extensions
             Exception defaultException = null)
         {
             HttpResponseMessage response = await client.GetAsync(uri);
-            response.ThrowIfNotSuccessStatusCode(defaultException);
+            await response.ThrowIfNotSuccessStatusCodeAndKeepPayload(defaultException);
+
             return response;
         }
 
@@ -40,7 +41,8 @@ namespace Kros.AspNetCore.Extensions
             Exception defaultException = null)
         {
             HttpResponseMessage response = await client.GetAsync(url);
-            response.ThrowIfNotSuccessStatusCode(defaultException);
+            await response.ThrowIfNotSuccessStatusCodeAndKeepPayload(defaultException);
+
             return response;
         }
 
@@ -65,7 +67,8 @@ namespace Kros.AspNetCore.Extensions
                 Content = new StringContent(jsonBody, Encoding.UTF8, "application/json")
             };
             HttpResponseMessage response = await client.SendAsync(request);
-            response.ThrowIfNotSuccessStatusCode(defaultException);
+            await response.ThrowIfNotSuccessStatusCodeAndKeepPayload(defaultException);
+
             return response;
         }
 

--- a/src/Kros.AspNetCore/Extensions/HttpResponseMessageExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/HttpResponseMessageExtensions.cs
@@ -15,7 +15,8 @@ namespace Kros.AspNetCore.Extensions
         /// Throws exception, depends on status code in http response, if HTTP response was not successful.
         /// </summary>
         /// <param name="response">Http response message.</param>
-        /// <param name="defaultException">Optional default exception to be returned on unsupported http code. Default is <see cref="UnknownStatusCodeException"/></param>
+        /// <param name="defaultException">Optional default exception to be returned on unsupported http code.
+        /// Default is <see cref="UnknownStatusCodeException"/></param>
         public static void ThrowIfNotSuccessStatusCode(this HttpResponseMessage response, Exception defaultException = null)
         {
             if (!response.IsSuccessStatusCode)
@@ -52,8 +53,11 @@ namespace Kros.AspNetCore.Extensions
         /// Persists response payload in exception.
         /// </summary>
         /// <param name="response">Http response message.</param>
-        /// <param name="defaultException">Optional default exception to be returned on unsupported http code. Default is <see cref="UnknownStatusCodeException"/></param>
-        public static async Task ThrowIfNotSuccessStatusCodeAndKeepPayload(this HttpResponseMessage response, Exception defaultException = null)
+        /// <param name="defaultException">Optional default exception to be returned on unsupported http code.
+        /// Default is <see cref="UnknownStatusCodeException"/></param>
+        public static async Task ThrowIfNotSuccessStatusCodeAndKeepPayload(
+            this HttpResponseMessage response,
+            Exception defaultException = null)
         {
             if (!response.IsSuccessStatusCode)
             {

--- a/src/Kros.AspNetCore/Extensions/HttpResponseMessageExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/HttpResponseMessageExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using Kros.AspNetCore.Exceptions;
 using System;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
 
 namespace Kros.AspNetCore.Extensions
 {
@@ -43,6 +45,43 @@ namespace Kros.AspNetCore.Extensions
                         }
                 }
             }
+        }
+
+        /// <summary>
+        /// Throws exception depending on status code in HTTP response, if HTTP response was not successful.
+        /// Persists response payload in exception.
+        /// </summary>
+        /// <param name="response">Http response message.</param>
+        /// <param name="defaultException">Optional default exception to be returned on unsupported http code. Default is <see cref="UnknownStatusCodeException"/></param>
+        public static async Task ThrowIfNotSuccessStatusCodeAndKeepPayload(this HttpResponseMessage response, Exception defaultException = null)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                switch (response.StatusCode)
+                {
+                    case System.Net.HttpStatusCode.PaymentRequired:
+                        throw (await GetExceptionWithResponseContent<PaymentRequiredException>(response));
+
+                    default:
+                        ThrowIfNotSuccessStatusCode(response, defaultException);
+                        break;
+                }
+            }
+        }
+
+        private static async Task<T> GetExceptionWithResponseContent<T>(HttpResponseMessage response)
+            where T : RequestUnsuccessfulException, new()
+        {
+            MediaTypeHeaderValue contentType = response.Content?.Headers.ContentType;
+            string content = await response.Content?.ReadAsStringAsync();
+
+            var exception = new T();
+            if (!string.IsNullOrEmpty(content))
+            {
+                exception.AddPayload(content, contentType);
+            }
+
+            return exception;
         }
     }
 }

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>2.43.0</Version>
+    <Version>2.44.0</Version>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
In the `HttpClientExtensions`, when request was not successful, an exception is thrown based on the response code. However, when this happens, response content is lost (exceptions that are thrown do not preserve information about it).
I added overload that allows for preserving response content and content type. For now this works only with `402 Payment required` status code, but it can be added for all the codes/exceptions we want to.