### PR TITLE
Make JsonPatchMapperConfig cache case-insensitive

### DIFF
--- a/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
+++ b/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
@@ -14,7 +14,7 @@ namespace Kros.AspNetCore.JsonPatch
     {
         private Func<string, string> _pathMapping;
         private ConcurrentDictionary<string, string> _mapping =
-            new ConcurrentDictionary<string, string>(StringComparer.CurrentCultureIgnoreCase);
+            new ConcurrentDictionary<string, string>(StringComparer.CurrentCulture);
 
         /// <summary>
         /// Creates new config for <typeparamref name="TSource"/> and store it for non parametric  extension

--- a/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
+++ b/src/Kros.AspNetCore/JsonPatch/JsonPatchMapperConfig.cs
@@ -14,7 +14,7 @@ namespace Kros.AspNetCore.JsonPatch
     {
         private Func<string, string> _pathMapping;
         private ConcurrentDictionary<string, string> _mapping =
-            new ConcurrentDictionary<string, string>(StringComparer.CurrentCulture);
+            new ConcurrentDictionary<string, string>(StringComparer.InvariantCulture);
 
         /// <summary>
         /// Creates new config for <typeparamref name="TSource"/> and store it for non parametric  extension

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>2.44.0</Version>
+    <Version>2.45.0</Version>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
@@ -132,6 +132,30 @@ namespace Kros.AspNetCore.Tests.JsonPatch
                 .BeEquivalentTo("SupplierAddressCountry");
         }
 
+        [Fact]
+        public void UseCaseSensitiveCaching()
+        {
+            var jsonPatch = new JsonPatchDocument();
+            jsonPatch.Replace("pRoperty1", "Value");
+
+            var serialized = JsonConvert.SerializeObject(jsonPatch);
+            var deserialized = JsonConvert.DeserializeObject<JsonPatchDocument<Document>>(serialized);
+
+            var columns = deserialized.GetColumnsNames();
+            columns.Should()
+                .BeEquivalentTo("PRoperty1");
+
+            var jsonPatch2 = new JsonPatchDocument();
+            jsonPatch2.Replace("property1", "Value");
+
+            var serialized2 = JsonConvert.SerializeObject(jsonPatch2);
+            var deserialized2 = JsonConvert.DeserializeObject<JsonPatchDocument<Document>>(serialized2);
+
+            var columns2 = deserialized2.GetColumnsNames();
+            columns2.Should()
+                .BeEquivalentTo("Property1");
+        }
+
         #region Nested classes
 
         public class Document

--- a/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/JsonPatch/JsonPatchDocumentExtensionsShould.cs
@@ -137,21 +137,19 @@ namespace Kros.AspNetCore.Tests.JsonPatch
         {
             var jsonPatch = new JsonPatchDocument();
             jsonPatch.Replace("pRoperty1", "Value");
-
             var serialized = JsonConvert.SerializeObject(jsonPatch);
             var deserialized = JsonConvert.DeserializeObject<JsonPatchDocument<Document>>(serialized);
 
-            var columns = deserialized.GetColumnsNames();
-            columns.Should()
-                .BeEquivalentTo("PRoperty1");
-
             var jsonPatch2 = new JsonPatchDocument();
             jsonPatch2.Replace("property1", "Value");
-
             var serialized2 = JsonConvert.SerializeObject(jsonPatch2);
             var deserialized2 = JsonConvert.DeserializeObject<JsonPatchDocument<Document>>(serialized2);
 
+            var columns = deserialized.GetColumnsNames();
             var columns2 = deserialized2.GetColumnsNames();
+
+            columns.Should()
+                .BeEquivalentTo("PRoperty1");
             columns2.Should()
                 .BeEquivalentTo("Property1");
         }


### PR DESCRIPTION
### Behaviour explanation
The `JsonPatchMapperConfig` caches mappings of properties to column names. It behaves as a singleton for a TSource. In a special case, it may cache incorrectly. For example, JSON patch property _dueDate_ should be mapped to column _DueDate_. If the first call to `GetColumnName` uses the property name with incorrect upper/lower-case letters, such as _duedate_, the cached column mapping will be to _Duedate_. After that, all following calls to `GetColumnName` even ith the correct property name _dueDate_ will be mapped incorrectly. Therefore, the _mapping Dictionary can no longer ignore case.
This behaviour occured in manually written Postman tests, where a typo in the first request could make the property unpatchable by later requests.
### How will this affect existing code?
* Calls with correct property name - no change
* Calls with incorrect property name - no change
* First call with incorrect property name, subsequent calls with correct property name - first call will have incorrect column name, as intended, subsequent correct calls will create a new, correct mapping
* First call with correct property name, subsequent calls with incorrect property name - first call will be correct, as intended. Subsequent incorrect calls will create their own mapping and will no longer be corrected by the ignore case behaviour.