### PR TITLE
App Configuration cache settings

### DIFF
--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -59,8 +59,7 @@ namespace Kros.AspNetCore.Extensions
                     {
                         config.Register(settings["AppConfig:SentinelKey"], true);
                     }
-                    if (!string.IsNullOrWhiteSpace(settings["AppConfig:RefreshInterval"]) &&
-                        TimeSpan.TryParse(settings["AppConfig:RefreshInterval"], out TimeSpan refreshInterval))
+                    if (TimeSpan.TryParse(settings["AppConfig:RefreshInterval"], out TimeSpan refreshInterval))
                     {
                         config.SetCacheExpiration(refreshInterval);
                     }

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -53,20 +53,20 @@ namespace Kros.AspNetCore.Extensions
                     .Connect(new Uri(settings["AppConfig:Endpoint"]), credential)
                     .ConfigureKeyVault(kv => kv.SetCredential(credential));
 
-                if (!string.IsNullOrWhiteSpace(settings["AppConfig:SentinelKey"]))
+                options.ConfigureRefresh(config =>
                 {
-                    options.ConfigureRefresh(config =>
+                    if (!string.IsNullOrWhiteSpace(settings["AppConfig:SentinelKey"]))
                     {
                         config.Register(settings["AppConfig:SentinelKey"], true);
-                        if (!string.IsNullOrWhiteSpace(settings["AppConfig:RefreshInterval"]) &&
-                            TimeSpan.TryParse(settings["AppConfig:RefreshInterval"], out TimeSpan refreshInterval))
-                        {
-                            config.SetCacheExpiration(refreshInterval);
-                        }
+                    }
+                    if (!string.IsNullOrWhiteSpace(settings["AppConfig:RefreshInterval"]) &&
+                        TimeSpan.TryParse(settings["AppConfig:RefreshInterval"], out TimeSpan refreshInterval))
+                    {
+                        config.SetCacheExpiration(refreshInterval);
+                    }
 
-                        refreshConfiguration?.Invoke(config);
-                    });
-                }
+                    refreshConfiguration?.Invoke(config);
+                });
 
                 IEnumerable<string> services = settings
                     .GetSection("AppConfig:Settings")


### PR DESCRIPTION
By default, applications query Azure App Configuration every 30 seconds for configuration updates. This behavior is not always suitable. Therefore I added a possibility for specifying custom Azure App Configuration caching settings via a delegate and also created basic caching settings configuration that can be set up via _appconfig.json_:
- `AppConfig:SentinelKey `- key in App Configuration that is queried for updates. If it is set, application will not query all keys for updated values, but only this one. If the value for sentinel key was changed, application will refresh **all** values.
- `AppConfig:RefreshInterval` - time interval for update querying (TimeSpan format)

Source: https://devblogs.microsoft.com/dotnet/redesigning-configuration-refresh-for-azure-app-configuration/