### PR TITLE
Fixed error with ConfigureRefresh().

### DIFF
--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -59,8 +59,7 @@ namespace Kros.AspNetCore.Extensions
                     {
                         config.Register(settings["AppConfig:SentinelKey"], true);
                     }
-                    if (!string.IsNullOrWhiteSpace(settings["AppConfig:RefreshInterval"]) &&
-                        TimeSpan.TryParse(settings["AppConfig:RefreshInterval"], out TimeSpan refreshInterval))
+                    if (TimeSpan.TryParse(settings["AppConfig:RefreshInterval"], out TimeSpan refreshInterval))
                     {
                         config.SetCacheExpiration(refreshInterval);
                     }

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -53,19 +53,19 @@ namespace Kros.AspNetCore.Extensions
                     .Connect(new Uri(settings["AppConfig:Endpoint"]), credential)
                     .ConfigureKeyVault(kv => kv.SetCredential(credential));
 
-                options.ConfigureRefresh(config =>
+                if (!string.IsNullOrWhiteSpace(settings["AppConfig:SentinelKey"]))
                 {
-                    if (!string.IsNullOrWhiteSpace(settings["AppConfig:SentinelKey"]))
+                    options.ConfigureRefresh(config =>
                     {
                         config.Register(settings["AppConfig:SentinelKey"], true);
-                    }
-                    if (TimeSpan.TryParse(settings["AppConfig:RefreshInterval"], out TimeSpan refreshInterval))
-                    {
-                        config.SetCacheExpiration(refreshInterval);
-                    }
+                        if (TimeSpan.TryParse(settings["AppConfig:RefreshInterval"], out TimeSpan refreshInterval))
+                        {
+                            config.SetCacheExpiration(refreshInterval);
+                        }
 
-                    refreshConfiguration?.Invoke(config);
-                });
+                        refreshConfiguration?.Invoke(config);
+                    });
+                }
 
                 IEnumerable<string> services = settings
                     .GetSection("AppConfig:Settings")

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -53,20 +53,20 @@ namespace Kros.AspNetCore.Extensions
                     .Connect(new Uri(settings["AppConfig:Endpoint"]), credential)
                     .ConfigureKeyVault(kv => kv.SetCredential(credential));
 
-                if (!string.IsNullOrWhiteSpace(settings["AppConfig:SentinelKey"]))
+                options.ConfigureRefresh(config =>
                 {
-                    options.ConfigureRefresh(config =>
+                    if (!string.IsNullOrWhiteSpace(settings["AppConfig:SentinelKey"]))
                     {
                         config.Register(settings["AppConfig:SentinelKey"], true);
-                        if (!string.IsNullOrWhiteSpace(settings["AppConfig:RefreshInterval"]) &&
-                            TimeSpan.TryParse(settings["AppConfig:RefreshInterval"], out TimeSpan refreshInterval))
-                        {
-                            config.SetCacheExpiration(refreshInterval);
-                        }
+                    }
+                    if (!string.IsNullOrWhiteSpace(settings["AppConfig:RefreshInterval"]) &&
+                        TimeSpan.TryParse(settings["AppConfig:RefreshInterval"], out TimeSpan refreshInterval))
+                    {
+                        config.SetCacheExpiration(refreshInterval);
+                    }
 
-                        refreshConfiguration?.Invoke(config);
-                    });
-                }
+                    refreshConfiguration?.Invoke(config);
+                });
 
                 IEnumerable<string> services = settings
                     .GetSection("AppConfig:Settings")


### PR DESCRIPTION
`ConfigureRefresh()` can be called only when at least one key-value setting pair will be registered. Therefore I moved the condition for checking `SentinelKey` above this method.