### PR TITLE
Load configuration from key vault

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,6 @@
 <Project>
   <ItemGroup>
+    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
     <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
     <PackageVersion Include="Azure.Identity" Version="1.5.0" />
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />

--- a/src/Kros.AspNetCore/Extensions/AppConfigOptions.cs
+++ b/src/Kros.AspNetCore/Extensions/AppConfigOptions.cs
@@ -20,7 +20,9 @@ namespace Kros.AspNetCore.Extensions
         public string IdentityClientId { get; set; } = "";
 
         /// <summary>
-        /// List of prefixes that specifies which values will be loaded from App Configuration.
+        /// List of prefixes that specifies which values will be loaded from App Configuration. Prefix is separated
+        /// from the rest of the configuration name with colon <c>:</c>. So prefix itself, cannot contain colon.
+        /// In this list, prefixes are set without trailing colon (<c>:</c>).
         /// </summary>
         public List<string> Settings { get; } = new List<string>();
 

--- a/src/Kros.AspNetCore/Extensions/AppConfigOptions.cs
+++ b/src/Kros.AspNetCore/Extensions/AppConfigOptions.cs
@@ -20,7 +20,7 @@ namespace Kros.AspNetCore.Extensions
         public string IdentityClientId { get; set; } = "";
 
         /// <summary>
-        /// List of prefixes that specifies shich values will be loaded from App Configuration.
+        /// List of prefixes that specifies which values will be loaded from App Configuration.
         /// </summary>
         public List<string> Settings { get; } = new List<string>();
 

--- a/src/Kros.AspNetCore/Extensions/KeyVaultOptions.cs
+++ b/src/Kros.AspNetCore/Extensions/KeyVaultOptions.cs
@@ -20,8 +20,9 @@ namespace Kros.AspNetCore.Extensions
         public string IdentityClientId { get; set; } = string.Empty;
 
         /// <summary>
-        /// List of prefixes that specifies which secrets will be loaded from key vault.
-        /// Prefixes are set without trailing dash (<c>-</c>).
+        /// List of prefixes that specifies which secrets will be loaded from key vault. Prefix is separated
+        /// from the rest of the secret name with dash <c>-</c>. So prefix itself, cannot contain dash.
+        /// In this list, prefixes are set without trailing dash (<c>-</c>).
         /// </summary>
         public List<string> Prefixes { get; } = new();
 

--- a/src/Kros.AspNetCore/Extensions/KeyVaultOptions.cs
+++ b/src/Kros.AspNetCore/Extensions/KeyVaultOptions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kros.AspNetCore.Extensions
+{
+    /// <summary>
+    /// Key vault configuration.
+    /// </summary>
+    public class KeyVaultOptions
+    {
+        /// <summary>
+        /// Name of the key vault to load configuration from.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Client ID of the user assigned managed identity, which will be used for connecting to key vault.
+        /// Leave this empty, if the service is using system assigned managed identity.
+        /// </summary>
+        public string IdentityClientId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// List of prefixes that specifies which secrets will be loaded from key vault.
+        /// Prefixes are set without trailing dash (<c>-</c>).
+        /// </summary>
+        public List<string> Prefixes { get; } = new();
+
+        /// <summary>
+        /// Gets or sets the timespan to wait between attempts at polling the Azure Key Vault for changes.
+        /// <code>null</code> to disable reloading.
+        /// </summary>
+        public TimeSpan? ReloadInterval { get; set; } = null;
+    }
+}

--- a/src/Kros.AspNetCore/Extensions/PrefixKeyVaultSecretManager.cs
+++ b/src/Kros.AspNetCore/Extensions/PrefixKeyVaultSecretManager.cs
@@ -40,7 +40,7 @@ namespace Kros.AspNetCore.Extensions
         /// <exception cref="ArgumentNullException">
         /// The value of <paramref name="prefixes"/> is <see langword="null"/>.
         /// </exception>
-        /// <exception cref="ArgumentException"><paramref name="prefixes"/> is an ampty list, or does not contain any valid
+        /// <exception cref="ArgumentException"><paramref name="prefixes"/> is an empty list, or does not contain any valid
         /// prefix. Prefix must not be an empty string or a string containing only white-space characters.
         /// </exception>
         public PrefixKeyVaultSecretManager(IEnumerable<string> prefixes)

--- a/src/Kros.AspNetCore/Extensions/PrefixKeyVaultSecretManager.cs
+++ b/src/Kros.AspNetCore/Extensions/PrefixKeyVaultSecretManager.cs
@@ -1,0 +1,86 @@
+﻿using Azure.Extensions.AspNetCore.Configuration.Secrets;
+using Azure.Security.KeyVault.Secrets;
+using Kros.Utils;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Kros.AspNetCore.Extensions
+{
+    /// <summary>
+    /// Implementation of <see cref="KeyVaultSecretManager"/> which loads only secrets with defined prefix(es).
+    /// Prefixes are set without trailing dash (<c>-</c>), but secret names must contain it. For example prefix
+    /// <c>Lorem</c> will load all secrets which name starts with <c>Lorem-</c>.
+    /// </summary>
+    public class PrefixKeyVaultSecretManager : KeyVaultSecretManager
+    {
+        private readonly HashSet<string> _prefixes = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Creates an instance with specified <paramref name="prefix"/>.
+        /// </summary>
+        /// <param name="prefix">Prefix for key vault secrets.</param>
+        /// <exception cref="ArgumentNullException">
+        /// The value of <paramref name="prefix"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The value of <paramref name="prefix"/> is empty string, or string containing only white-space characters.
+        /// </exception>
+        public PrefixKeyVaultSecretManager(string prefix)
+        {
+            Check.NotNullOrWhiteSpace(prefix, nameof(prefix));
+            AddPrefix(prefix);
+        }
+
+        /// <summary>
+        /// Creates an instance with specified <paramref name="prefixes"/>.
+        /// </summary>
+        /// <param name="prefixes"></param>
+        /// <exception cref="ArgumentNullException">
+        /// The value of <paramref name="prefixes"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="prefixes"/> is an ampty list, or does not contain any valid
+        /// prefix. Prefix must not be an empty string or a string containing only white-space characters.
+        /// </exception>
+        public PrefixKeyVaultSecretManager(IEnumerable<string> prefixes)
+        {
+            Check.NotNull(prefixes, nameof(prefixes));
+            foreach (string prefix in prefixes)
+            {
+                if (!string.IsNullOrWhiteSpace(prefix))
+                {
+                    AddPrefix(prefix);
+                }
+            }
+            if (_prefixes.Count == 0)
+            {
+                throw new ArgumentException("At least one valid prefix must be supplied. Prefix cannot be an empty string " +
+                    "or consists only of white-space characters.", nameof(prefixes));
+            }
+        }
+
+        private void AddPrefix(string prefix) => _prefixes.Add(prefix + "-");
+
+        /// <summary>
+        /// Checks if <see cref="KeyVaultSecret"/> value should be retrieved. The secret is retrieved, if its name
+        /// has one of the defined prefixes.
+        /// </summary>
+        /// <param name="secret">The <see cref="SecretProperties"/> instance.</param>
+        /// <returns><code>true</code> if secrets value should be loaded, otherwise <code>false</code>.</returns>
+        public override bool Load(SecretProperties secret)
+            => _prefixes.Any(prefix => secret.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>
+        /// Maps secret to a configuration key. Prefix is removed from secret name and double dashes (<c>--</c>)
+        /// are replaced with colon (<c>:</c>).
+        /// </summary>
+        /// <param name="secret">The <see cref="KeyVaultSecret"/> instance.</param>
+        /// <returns>Configuration key name to store secret value.</returns>
+        public override string GetKey(KeyVaultSecret secret)
+        {
+            int keyStart = secret.Name.IndexOf('-') + 1;
+            return secret.Name[keyStart..].Replace("--", ConfigurationPath.KeyDelimiter);
+        }
+    }
+}

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Uris" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" />
     <PackageReference Include="Kros.Utils" />

--- a/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
@@ -118,7 +118,7 @@ namespace Kros.AspNetCore.Tests.Extensions
             {
                 Name = "example-kv",
                 IdentityClientId = "Lorem",
-                ReloadInterval = TimeSpan.FromSeconds(2 * 60 + 15)
+                ReloadInterval = TimeSpan.FromSeconds((2 * 60) + 15)
             };
             expectedKv.Prefixes.AddRange(new[] { "Example1", "Example2" });
 

--- a/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
@@ -12,6 +12,8 @@ namespace Kros.AspNetCore.Tests.Extensions
 {
     public class ConfigurationBuilderExtensionsShould
     {
+        #region App configuration
+
         [Fact]
         public void LoadAppConfigOptions()
         {
@@ -101,6 +103,48 @@ namespace Kros.AspNetCore.Tests.Extensions
             config.Sources.Count.Should().Be(0);
         }
 
+        #endregion
+
+        #region Key vault
+
+        [Fact]
+        public void LoadKeyVaultOptions()
+        {
+            IConfiguration cfg = GetConfiguration();
+            KeyVaultOptions actualKv = new();
+            cfg.Bind("KeyVault", actualKv);
+
+            var expectedKv = new KeyVaultOptions
+            {
+                Name = "example-kv",
+                IdentityClientId = "Lorem",
+                ReloadInterval = TimeSpan.FromSeconds(2 * 60 + 15)
+            };
+            expectedKv.Prefixes.AddRange(new[] { "Example1", "Example2" });
+
+            actualKv.Should().BeEquivalentTo(expectedKv);
+        }
+
+        [Fact]
+        public void LoadEmptyKeyVaultOptions()
+        {
+            IConfiguration cfg = new ConfigurationBuilder().Build();
+            KeyVaultOptions actualKv = new();
+            cfg.Bind("KeyVault", actualKv);
+
+            var expectedKv = new KeyVaultOptions
+            {
+                Name = string.Empty,
+                IdentityClientId = string.Empty
+            };
+
+            actualKv.Should().BeEquivalentTo(expectedKv);
+        }
+
+        #endregion
+
+        #region Helpers
+
         private HostBuilderContext CreateHostBuilderContext()
         {
             var context = new HostBuilderContext(new Dictionary<object, object>());
@@ -112,5 +156,7 @@ namespace Kros.AspNetCore.Tests.Extensions
 
         private static IConfiguration GetConfiguration()
            => new ConfigurationBuilder().AddJsonFile("Extensions\\appsettings.configuration-test.json").Build();
+
+        #endregion
     }
 }

--- a/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Extensions/ConfigurationBuilderExtensionsShould.cs
@@ -141,6 +141,42 @@ namespace Kros.AspNetCore.Tests.Extensions
             actualKv.Should().BeEquivalentTo(expectedKv);
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("lorem")]
+        public void ShouldAddKeyVaultSourceIfNameIsPresent(string prefix)
+        {
+            IConfigurationBuilder cfgBuilder = new ConfigurationBuilder();
+            cfgBuilder.AddAzureKeyVault(options =>
+            {
+                options.Name = "example-kv";
+                if (prefix is not null)
+                {
+                    options.Prefixes.Add(prefix);
+                }
+            });
+
+            cfgBuilder.Sources.Should().HaveCount(1);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("lorem")]
+        public void ShouldNotAddKeyVaultSourceIfNameIsNotPresent(string prefix)
+        {
+            IConfigurationBuilder cfgBuilder = new ConfigurationBuilder();
+            cfgBuilder.AddAzureKeyVault(options =>
+            {
+                options.Name = "";
+                if (prefix is not null)
+                {
+                    options.Prefixes.Add(prefix);
+                }
+            });
+
+            cfgBuilder.Sources.Should().HaveCount(0);
+        }
+
         #endregion
 
         #region Helpers

--- a/tests/Kros.AspNetCore.Tests/Extensions/PrefixKeyVaultSecretManagerShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Extensions/PrefixKeyVaultSecretManagerShould.cs
@@ -1,0 +1,74 @@
+﻿using Azure.Security.KeyVault.Secrets;
+using FluentAssertions;
+using Kros.AspNetCore.Extensions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Kros.AspNetCore.Tests.Extensions
+{
+    public class PrefixKeyVaultSecretManagerShould
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(" \t \n")]
+        public void ThrowArgumentExceptionIfPrefixNotSet(string prefix)
+        {
+            Func<PrefixKeyVaultSecretManager> action = () => new PrefixKeyVaultSecretManager(prefix);
+            action.Should().Throw<ArgumentException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ThrowArgumentExceptionIfNoValidPrefix_Data))]
+        public void ThrowArgumentExceptionIfNoValidPrefix(IEnumerable<string> prefix)
+        {
+            Func<PrefixKeyVaultSecretManager> action = () => new PrefixKeyVaultSecretManager(prefix);
+            action.Should().Throw<ArgumentException>();
+        }
+
+        public static IEnumerable<object[]> ThrowArgumentExceptionIfNoValidPrefix_Data()
+        {
+            yield return new object[] { null };
+            yield return new object[] { Array.Empty<string>() };
+            yield return new object[] { new string[] { "", "   ", "\t" } };
+        }
+
+        [Theory]
+        [InlineData("lorem-ipsum1", true)]
+        [InlineData("Lorem-ipsum2", true)]
+        [InlineData("LOREM-ipsum3", true)]
+        [InlineData("lorem-hierarchey--key--one", true)]
+        [InlineData("lorem-hierarchey--key--two", true)]
+        [InlineData("lorem-non-hierarchy-key", true)]
+        [InlineData("loremWithoutDash", false)]
+        [InlineData("invalidPrefix-keyName", false)]
+        [InlineData("noPrefix", false)]
+        [InlineData("dolor-sitAmet", true)]
+        public void LoadPrefixedValue(string secretName, bool loadIt)
+        {
+            PrefixKeyVaultSecretManager manager = CreateManager();
+            SecretProperties secret = new(secretName);
+            manager.Load(secret).Should().Be(loadIt);
+        }
+
+        [Theory]
+        [InlineData("lorem-ipsum1", "ipsum1")]
+        [InlineData("Lorem-ipsum2", "ipsum2")]
+        [InlineData("LOREM-ipsum3", "ipsum3")]
+        [InlineData("lorem-hierarchy--key--one", "hierarchy:key:one")]
+        [InlineData("lorem-hierarchy--key--two", "hierarchy:key:two")]
+        [InlineData("lorem-non-hierarchy-key", "non-hierarchy-key")]
+        [InlineData("dolor-sitAmet", "sitAmet")]
+        [InlineData("noPrefix", "noPrefix")]
+        public void CreateCorrectConfigKey(string secretName, string configKey)
+        {
+            PrefixKeyVaultSecretManager manager = CreateManager();
+            KeyVaultSecret secret = new(secretName, string.Empty);
+            manager.GetKey(secret).Should().Be(configKey);
+        }
+
+        private static PrefixKeyVaultSecretManager CreateManager() => new(new[] { "Lorem", "DOLOR" });
+    }
+}

--- a/tests/Kros.AspNetCore.Tests/Extensions/appsettings.configuration-test.json
+++ b/tests/Kros.AspNetCore.Tests/Extensions/appsettings.configuration-test.json
@@ -1,4 +1,11 @@
 {
+  "KeyVault": {
+    "Name": "example-kv",
+    "Prefixes": [ "Example1", "Example2" ],
+    "IdentityClientId": "Lorem",
+    "ReloadInterval": "00:02:15"
+  },
+
   "AppConfig": {
     "Endpoint": "https://example.azconfig.io",
     "IdentityClientId": "Ipsum",


### PR DESCRIPTION
Closes #163 

Implemented `IConfigurationBuilder.AddAzureKeyVault` extension method. This allows to load secrets in key value as configuration values.