### PR TITLE
Cache only part of the url path

### DIFF
--- a/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
@@ -84,7 +84,11 @@ namespace Kros.AspNetCore.Authorization
                     httpContext.Request.Headers,
                     _jwtAuthorizationOptions.CacheKeyHttpHeaders,
                     out string cacheKeyPart);
-                cacheKeyPart += GetUrlPathForCacheKey(httpContext);
+                string urlPathForCache = GetUrlPathForCacheKey(httpContext);
+                if (urlPathForCache != null)
+                {
+                    cacheKeyPart += urlPathForCache;
+                }
                 int key = GetKey(token, cacheKeyPart);
 
                 if (!memoryCache.TryGetValue(key, out string jwtToken))

--- a/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayAuthorizationMiddleware.cs
@@ -2,6 +2,7 @@
 using Kros.AspNetCore.ServiceDiscovery;
 using Kros.Utils;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -198,10 +199,13 @@ namespace Kros.AspNetCore.Authorization
 
         internal string GetUrlPathForCacheKey(HttpContext httpContext)
         {
+            var routeValues = httpContext.GetRouteData().Values;
+
             if (!string.IsNullOrWhiteSpace(_jwtAuthorizationOptions.CacheKeyUrlPathRegexPattern)
                 && !string.IsNullOrWhiteSpace(httpContext.Request.Path))
             {
-                if (_cacheRegex.Match(httpContext.Request.Path) is var match && match.Success)
+                Match match = _cacheRegex.Match(httpContext.Request.Path);
+                if (match.Success)
                 {
                     return match.Groups.Values.Last().Value;
                 }
@@ -210,9 +214,7 @@ namespace Kros.AspNetCore.Authorization
         }
 
         internal static int GetKey(StringValues value, string additionalKeyPart = null)
-        {
-            return (additionalKeyPart is null) ? HashCode.Combine(value) : HashCode.Combine(value, additionalKeyPart);
-        }
+            => (additionalKeyPart is null) ? HashCode.Combine(value) : HashCode.Combine(value, additionalKeyPart);
 
         private void AddUserProfileClaimsToIdentityAndHttpHeaders(HttpContext httpContext, string userJwtToken)
             => httpContext.Request.Headers[HeaderNames.Authorization] = $"{JwtAuthorizationHelper.AuthTokenPrefix} {userJwtToken}";

--- a/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
+++ b/src/Kros.AspNetCore/Authorization/GatewayJwtAuthorizationOptions.cs
@@ -73,5 +73,10 @@ namespace Kros.AspNetCore.Authorization
         /// Headers which will be used as cache key for authorization token.
         /// </summary>
         public List<string> CacheKeyHttpHeaders { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Part of url path which will be used as cache key for authorization token.
+        /// </summary>
+        public string CacheKeyUrlPathRegexPattern { get; set; }
     }
 }

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
@@ -419,30 +419,30 @@ namespace Kros.AspNetCore.Tests.Authorization
                 .Contain($"Bearer {JwtToken}");
         }
 
-        //[Theory]
-        //[InlineData(null, null, null)]
-        //[InlineData("", "", null)]
-        //[InlineData("/companies/123456", "/companies/(?<companyId>\\d+)", "123456")]
-        //[InlineData("/companies/123456789/other-segment", "/companies/(?<companyId>\\d+)/other-segment", "123456789")]
-        //[InlineData("/companies/123456", null, null)]
-        //[InlineData("", "/companies/(?<companyId>\\d+)", null)]
-        //public void CacheUrlPath(string requestPath, string urlPathRegexPattern, string expectedResult)
-        //{
-        //    (_, var middleware) = CreateMiddleware(
-        //        HttpStatusCode.OK,
-        //        TimeSpan.Zero,
-        //        new List<string>(),
-        //        new GatewayJwtAuthorizationOptions()
-        //        {
-        //            CacheKeyUrlPathRegexPattern = urlPathRegexPattern
-        //        });
-        //    var context = new DefaultHttpContext();
-        //    context.Request.Path = requestPath;
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData("", "", null)]
+        [InlineData("/companies/123456", "/companies/(?<companyId>\\d+)", "123456")]
+        [InlineData("/companies/123456789/other-segment", "/companies/(?<companyId>\\d+)/other-segment", "123456789")]
+        [InlineData("/companies/123456", null, null)]
+        [InlineData("", "/companies/(?<companyId>\\d+)", null)]
+        public void CacheUrlPath(string requestPath, string urlPathRegexPattern, string expectedResult)
+        {
+            (_, var middleware) = CreateMiddleware(
+                HttpStatusCode.OK,
+                TimeSpan.Zero,
+                new List<string>(),
+                new GatewayJwtAuthorizationOptions()
+                {
+                    CacheKeyUrlPathRegexPattern = urlPathRegexPattern
+                });
+            var context = new DefaultHttpContext();
+            context.Request.Path = requestPath;
 
-        //    string urlPathForCache = middleware.GetUrlPathForCacheKey(context);
+            string urlPathForCache = middleware.GetUrlPathForCacheKey(context);
 
-        //    urlPathForCache.Should().Be(expectedResult);
-        //}
+            urlPathForCache.Should().Be(expectedResult);
+        }
 
         private static (IHttpClientFactory, GatewayAuthorizationMiddleware) CreateMiddleware(HttpStatusCode statusCode)
             => CreateMiddleware(statusCode, TimeSpan.Zero, new List<string>());

--- a/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
@@ -419,6 +419,31 @@ namespace Kros.AspNetCore.Tests.Authorization
                 .Contain($"Bearer {JwtToken}");
         }
 
+        //[Theory]
+        //[InlineData(null, null, null)]
+        //[InlineData("", "", null)]
+        //[InlineData("/companies/123456", "/companies/(?<companyId>\\d+)", "123456")]
+        //[InlineData("/companies/123456789/other-segment", "/companies/(?<companyId>\\d+)/other-segment", "123456789")]
+        //[InlineData("/companies/123456", null, null)]
+        //[InlineData("", "/companies/(?<companyId>\\d+)", null)]
+        //public void CacheUrlPath(string requestPath, string urlPathRegexPattern, string expectedResult)
+        //{
+        //    (_, var middleware) = CreateMiddleware(
+        //        HttpStatusCode.OK,
+        //        TimeSpan.Zero,
+        //        new List<string>(),
+        //        new GatewayJwtAuthorizationOptions()
+        //        {
+        //            CacheKeyUrlPathRegexPattern = urlPathRegexPattern
+        //        });
+        //    var context = new DefaultHttpContext();
+        //    context.Request.Path = requestPath;
+
+        //    string urlPathForCache = middleware.GetUrlPathForCacheKey(context);
+
+        //    urlPathForCache.Should().Be(expectedResult);
+        //}
+
         private static (IHttpClientFactory, GatewayAuthorizationMiddleware) CreateMiddleware(HttpStatusCode statusCode)
             => CreateMiddleware(statusCode, TimeSpan.Zero, new List<string>());
 


### PR DESCRIPTION
Add support for caching only part of the url path. This solution uses regex to determine what to cache.

Example for setting:
`"GatewayJwtAuthorization": {
        "CacheKeyUrlPathRegexPattern": "/companies/(?<companyId>\\d+)"
}`
