### PR TITLE
Update references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,15 +5,15 @@
     <PackageVersion Include="Azure.Identity" Version="1.5.0" />
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
     <PackageVersion Include="FluentAssertions" Version="6.5.1" />
-    <PackageVersion Include="FluentValidation" Version="10.4.0" />
-    <PackageVersion Include="Hellang.Middleware.ProblemDetails" Version="6.4.0" />
+    <PackageVersion Include="FluentValidation" Version="11.4.0" />
+    <PackageVersion Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
     <PackageVersion Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageVersion Include="Kros.AspNetCore" Version="3.4.2" />
-    <PackageVersion Include="Kros.Utils" Version="1.19.0" />
+    <PackageVersion Include="Kros.Utils" Version="2.0.0" />
     <PackageVersion Include="MassTransit.AspNetCore" Version="7.1.8" />
     <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="7.1.8" />
     <PackageVersion Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />


### PR DESCRIPTION
- **FluentValidation:** we already use version 11 in some of the platform projects.
- **Hellang.Middleware.ProblemDetails:** _Kros.ProblemDetails.Extensions_ targets .NET 6, so this reference is updated to also target .NET 6.
- **Kros.Utils:** targets .NET6.
- **Microsoft.ApplicationInsights.AspNetCore:** version 2.20.0 is marked as deprecated.