### PR TITLE
Add initCredential callback

### DIFF
--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -172,13 +172,13 @@ namespace Kros.AspNetCore.Extensions
         {
             if (credentialOptions.ManagedIdentityClientId != null)
             {
-                credentialOptions.ExcludeEnvironmentCredential = false;
-                credentialOptions.ExcludeInteractiveBrowserCredential = false;
-                credentialOptions.ExcludeAzurePowerShellCredential = false;
-                credentialOptions.ExcludeSharedTokenCacheCredential = false;
-                credentialOptions.ExcludeVisualStudioCodeCredential = false;
-                credentialOptions.ExcludeVisualStudioCredential = false;
-                credentialOptions.ExcludeAzureCliCredential = false;
+                credentialOptions.ExcludeAzurePowerShellCredential = true;
+                credentialOptions.ExcludeAzureCliCredential = true;
+                credentialOptions.ExcludeEnvironmentCredential = true;
+                credentialOptions.ExcludeInteractiveBrowserCredential = true;
+                credentialOptions.ExcludeSharedTokenCacheCredential = true;
+                credentialOptions.ExcludeVisualStudioCodeCredential = true;
+                credentialOptions.ExcludeVisualStudioCredential = true;
             }
         }
     }

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -64,6 +64,7 @@ namespace Kros.AspNetCore.Extensions
         /// <param name="config">The configuration.</param>
         /// <param name="environmentName">Environment name.</param>
         /// <param name="refreshConfiguration">A callback used to configure Azure App Configuration refresh options.</param>
+        /// <param name="initCredential">A callback used to configure Azure credential.</param>
         /// <returns>The same instance of the Microsoft.Extensions.Hosting.IHostBuilder for chaining.</returns>
         /// <remarks>
         /// Configuration should contain <b>AppConfig</b> section, which is mapped to <see cref="AppConfigOptions "/> class.
@@ -71,7 +72,8 @@ namespace Kros.AspNetCore.Extensions
         public static IConfigurationBuilder AddAzureAppConfig(
             this IConfigurationBuilder config,
             string environmentName,
-            Action<AzureAppConfigurationRefreshOptions> refreshConfiguration = null)
+            Action<AzureAppConfigurationRefreshOptions> refreshConfiguration = null,
+            Action<DefaultAzureCredential> initCredential = null)
         {
             IConfigurationRoot settings = config.Build();
             AppConfigOptions appConfig = new();
@@ -85,6 +87,8 @@ namespace Kros.AspNetCore.Extensions
             config.AddAzureAppConfiguration(options =>
             {
                 DefaultAzureCredential credential = CreateAzureCredential(appConfig.IdentityClientId);
+                initCredential?.Invoke(credential);
+
                 options
                     .Connect(new Uri(appConfig.Endpoint), credential)
                     .ConfigureKeyVault(kv => kv.SetCredential(credential));
@@ -118,6 +122,7 @@ namespace Kros.AspNetCore.Extensions
         /// <param name="config">The configuration.</param>
         /// <param name="hostingContext">The hosting context.</param>
         /// <param name="refreshConfiguration">A callback used to configure Azure App Configuration refresh options.</param>
+        /// <param name="initCredential">A callback used to configure Azure credential.</param>
         /// <returns>The same instance of the Microsoft.Extensions.Hosting.IHostBuilder for chaining.</returns>
         /// <remarks>
         /// Configuration should contain <b>AppConfig</b> section, which is mapped to <see cref="AppConfigOptions "/> class.
@@ -125,16 +130,9 @@ namespace Kros.AspNetCore.Extensions
         public static IConfigurationBuilder AddAzureAppConfig(
             this IConfigurationBuilder config,
             HostBuilderContext hostingContext,
-            Action<AzureAppConfigurationRefreshOptions> refreshConfiguration = null)
-            => config.AddAzureAppConfig(hostingContext.HostingEnvironment.EnvironmentName, refreshConfiguration);
-
-        /// <inheritdoc cref="AddAzureAppConfig(IConfigurationBuilder, HostBuilderContext, Action{AzureAppConfigurationRefreshOptions})"/>
-        [Obsolete("Use AddAzureAppConfig(...) method.")]
-        public static IConfigurationBuilder AddAzureAppConfiguration(
-            this IConfigurationBuilder config,
-            HostBuilderContext hostingContext,
-            Action<AzureAppConfigurationRefreshOptions> refreshConfiguration = null)
-            => AddAzureAppConfig(config, hostingContext, refreshConfiguration);
+            Action<AzureAppConfigurationRefreshOptions> refreshConfiguration = null,
+            Action<DefaultAzureCredential> initCredential = null)
+            => config.AddAzureAppConfig(hostingContext.HostingEnvironment.EnvironmentName, refreshConfiguration, initCredential);
 
         private static void ConfigureCacheRefresh(
             AzureAppConfigurationOptions options,

--- a/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
+++ b/src/Kros.AspNetCore/Extensions/ConfigurationBuilderExtenstions.cs
@@ -164,7 +164,22 @@ namespace Kros.AspNetCore.Extensions
                 // 'null' means use system assigned identity (if possible). Empty string is invalid value.
                 ManagedIdentityClientId = string.IsNullOrEmpty(managedIdentityClientId) ? null : managedIdentityClientId
             };
+            ExcludeCredentials(credentialOptions);
             return new DefaultAzureCredential(credentialOptions);
+        }
+
+        private static void ExcludeCredentials(DefaultAzureCredentialOptions credentialOptions)
+        {
+            if (credentialOptions.ManagedIdentityClientId != null)
+            {
+                credentialOptions.ExcludeEnvironmentCredential = false;
+                credentialOptions.ExcludeInteractiveBrowserCredential = false;
+                credentialOptions.ExcludeAzurePowerShellCredential = false;
+                credentialOptions.ExcludeSharedTokenCacheCredential = false;
+                credentialOptions.ExcludeVisualStudioCodeCredential = false;
+                credentialOptions.ExcludeVisualStudioCredential = false;
+                credentialOptions.ExcludeAzureCliCredential = false;
+            }
         }
     }
 }

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <Version>4.0.0</Version>
+    <Version>3.6.0</Version>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <Version>3.5.1</Version>
+    <Version>4.0.0</Version>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>


### PR DESCRIPTION
Pridanie `initCredential` callbacku, aby bolo možné konfigurovať `DefaultAzureCredential` na strane klienta _(projektu, kde sa to používa)_

Pôvodná motivácia bola umožniť vypnúť jednotlivé spôsoby overovania kvôli tomu, že pripojenie na _AppConfiguration (respektíve potom aj KeyVault)_ je pomalé.
Viac info v tomto článku https://scottsauber.com/2022/05/10/improving-azure-key-vault-performance-in-asp-net-core-by-up-to-10x/

```csharp
config.AddAzureAppConfig(environmentName, (c)=>{
  c.ExcludeEnvironmentCredential = false;
  c.ExcludeInteractiveBrowserCredential = false;
  c.ExcludeAzurePowerShellCredential = false;
  c.ExcludeSharedTokenCacheCredential = false;
  c.ExcludeVisualStudioCodeCredential = false;
  c.ExcludeVisualStudioCredential = false;
  c.ExcludeAzureCliCredential = false;
  c.ExcludeManagedIdentityCredential = true;
});
```

---

Odstránil som obsolete preťaženie a preto som aj zvýšil verziu na `4.0.0`, kľudne môžem zmeniť.