### PR TITLE
HeadersTelemetryInitializer

### DIFF
--- a/src/Kros.ApplicationInsights.Extensions/ApplicationInsightsExtension.cs
+++ b/src/Kros.ApplicationInsights.Extensions/ApplicationInsightsExtension.cs
@@ -1,10 +1,12 @@
 ﻿using Kros.ApplicationInsights.Extensions;
+using Kros.Utils;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Options;
+using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -80,5 +82,41 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return configurationSection.Get<ApplicationInsightsOptions>();
         }
+
+        /// <summary>
+        /// Adds the headers telemetry initializer.
+        /// </summary>
+        /// <param name="services">The services.</param>
+        /// <param name="propertyNameResolver">The property name resolver.</param>
+        /// <param name="headersToCapture">The headers to capture.</param>
+        public static IServiceCollection AddHeadersTelemetryInitializer(
+            this IServiceCollection services,
+            Func<string, string> propertyNameResolver = null,
+            params string[] headersToCapture)
+        {
+            Check.GreaterThan(headersToCapture.Length, 0, nameof(headersToCapture));
+
+            services.AddHttpContextAccessor();
+            services.Configure<HeadersTelemetryInitializer.HeadersToCaptureOptions>(options =>
+            {
+                options.Add(headersToCapture);
+                if (propertyNameResolver is not null)
+                {
+                    options.PropertyNameResolver = propertyNameResolver;
+                }
+            });
+            services.AddSingleton<ITelemetryInitializer, HeadersTelemetryInitializer>();
+            return services;
+        }
+
+        /// <summary>
+        /// Adds the headers telemetry initializer.
+        /// </summary>
+        /// <param name="services">The services.</param>
+        /// <param name="headersToCapture">The headers to capture.</param>
+        public static IServiceCollection AddHeadersTelemetryInitializer(
+            this IServiceCollection services,
+            params string[] headersToCapture)
+            => services.AddHeadersTelemetryInitializer(null, headersToCapture);
     }
 }

--- a/src/Kros.ApplicationInsights.Extensions/HeadersTelemetryInitializer.cs
+++ b/src/Kros.ApplicationInsights.Extensions/HeadersTelemetryInitializer.cs
@@ -1,0 +1,69 @@
+﻿using Kros.Utils;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Kros.ApplicationInsights.Extensions
+{
+    internal class HeadersTelemetryInitializer : ITelemetryInitializer
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly HeadersToCaptureOptions _headersToCapture;
+
+        public HeadersTelemetryInitializer(
+            IHttpContextAccessor httpContextAccessor,
+            IOptions<HeadersToCaptureOptions> headersToCapture)
+        {
+            _httpContextAccessor = Check.NotNull(httpContextAccessor, nameof(httpContextAccessor));
+            _headersToCapture = Check.NotNull(headersToCapture.Value, nameof(headersToCapture));
+        }
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (telemetry is RequestTelemetry requestTelemetry)
+            {
+                HttpContext context = _httpContextAccessor.HttpContext;
+                if (context != null)
+                {
+                    foreach (string headerKey in _headersToCapture)
+                    {
+                        if (context.Request.Headers.TryGetValue(headerKey, out StringValues headerValue))
+                        {
+                            requestTelemetry.Properties[_headersToCapture.PropertyNameResolver(headerKey)]
+                                = headerValue.ToString();
+                        }
+                    }
+                }
+            }
+        }
+
+        internal class HeadersToCaptureOptions : IEnumerable<string>
+        {
+            private readonly HashSet<string> _headersToCapture = new(StringComparer.OrdinalIgnoreCase);
+
+            public Func<string, string> PropertyNameResolver { get; set; } = (headerKey) => $"Header-{headerKey}";
+
+            public IEnumerator<string> GetEnumerator() => _headersToCapture.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public HeadersToCaptureOptions Add(params string[] headersToCapture)
+            {
+                foreach (string headerKey in headersToCapture)
+                {
+                    Add(headerKey);
+                }
+                return this;
+            }
+
+            private void Add(string headerKey)
+                => _headersToCapture.Add(Check.NotNullOrWhiteSpace(headerKey, nameof(headerKey)));
+        }
+    }
+}

--- a/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
+++ b/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <Description>Extensions to facilitate work with Application Insights.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Kros.ApplicationInsights.Extensions/README.md
+++ b/src/Kros.ApplicationInsights.Extensions/README.md
@@ -34,4 +34,18 @@ Ak sa jedná o request na url `/health`, request sa nezahrnie do telemetry.
 
 ## FilterSyntheticRequestsProcessor
 
-Preskoćí syntetické requesty - requesty od botov, z web searchu a pod.
+Preskočí syntetické requesty - requesty od botov, z web searchu a pod.
+
+## HeadersTelemetryInitializer
+
+Umožní logovať ľubovoľné hlavičky z requestu.
+
+```csharp
+services.AddHeadersTelemetryInitializer("my-custom-header-1", "my-custom-header-2");
+```
+
+Hlavička bude pridaná do properties s kľúčom `Header-{headerKey}`. Pokiaľ chcete tento názov zmeniť, použite na to property name resolver.
+
+```csharp
+services.AddHeadersTelemetryInitializer((headerKey) => $"MyPrefix-{headerKey}-myPostfix","my-custom-header-1", "my-custom-header-2");
+```

--- a/tests/Kros.ApplicationInsights.Extensions.Tests/HeadersTelemetryInitializerShould.cs
+++ b/tests/Kros.ApplicationInsights.Extensions.Tests/HeadersTelemetryInitializerShould.cs
@@ -1,0 +1,91 @@
+﻿using FluentAssertions;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.AspNetCore.Http;
+using System;
+using Xunit;
+
+namespace Kros.ApplicationInsights.Extensions.Tests
+{
+    public class HeadersTelemetryInitializerShould
+    {
+        [Fact]
+        public void AddHeadersToTelemetry()
+        {
+            HeadersTelemetryInitializer initializer = CreateInitializer(null, "Accept", "Accept-Language", "x-my-custom");
+            ITelemetry telemetry = FakeTelemetry();
+
+            initializer.Initialize(telemetry);
+
+            (telemetry as RequestTelemetry)
+                .Properties
+                .Should()
+                .ContainKeys("Header-Accept", "Header-Accept-Language", "Header-x-my-custom");
+        }
+
+        [Fact]
+        public void AddOnlyDefinedHeaders()
+        {
+            HeadersTelemetryInitializer initializer = CreateInitializer(null, "Accept-Language", "UnExistingHeader");
+            ITelemetry telemetry = FakeTelemetry();
+
+            initializer.Initialize(telemetry);
+
+            (telemetry as RequestTelemetry)
+                .Properties
+                .Should()
+                .ContainKeys("Header-Accept-Language");
+        }
+
+        [Fact]
+        public void AddWithCustomNames()
+        {
+            HeadersTelemetryInitializer initializer = CreateInitializer((k) => $"myprefix-{k}-mysufix", "Accept-Language", "UnExistingHeader");
+            ITelemetry telemetry = FakeTelemetry();
+
+            initializer.Initialize(telemetry);
+
+            (telemetry as RequestTelemetry)
+                .Properties
+                .Should()
+                .ContainKeys("myprefix-Accept-Language-mysufix");
+        }
+
+        private static HeadersTelemetryInitializer CreateInitializer(
+            Func<string, string> propertyNameResolver,
+            params string[] headersToCapture)
+        {
+            HeadersTelemetryInitializer.HeadersToCaptureOptions option
+                = new HeadersTelemetryInitializer.HeadersToCaptureOptions()
+                .Add(headersToCapture);
+            if (propertyNameResolver is not null)
+            {
+                option.PropertyNameResolver = propertyNameResolver;
+            }
+
+            return new(
+                FakeHttpContextAccessor(),
+                Microsoft.Extensions.Options.Options.Create(option));
+        }
+
+        private static ITelemetry FakeTelemetry()
+        {
+            return new RequestTelemetry();
+        }
+
+        private static IHttpContextAccessor FakeHttpContextAccessor()
+        {
+            DefaultHttpContext httpContext = new();
+            IHttpContextAccessor context = new HttpContextAccessor()
+            {
+                HttpContext = httpContext
+            };
+
+            context.HttpContext.Request.Headers.Add("Accept", "application/json");
+            context.HttpContext.Request.Headers.Add("Accept-Language", "en-US,en;q=0.9,sk;q=0.8,cs;q=0.7");
+            context.HttpContext.Request.Headers.Add("x-my-custom", "custom value");
+
+            return context;
+        }
+    }
+}


### PR DESCRIPTION
## HeadersTelemetryInitializer

Umožní logovať ľubovoľné hlavičky z requestu.

```csharp
services.AddHeadersTelemetryInitializer("my-custom-header-1", "my-custom-header-2");
```

Hlavička bude pridaná do properties s kľúčom `Header-{headerKey}`. Pokiaľ chcete tento názov zmeniť, použite na to property name resolver.

```csharp
services.AddHeadersTelemetryInitializer((headerKey) => $"MyPrefix-{headerKey}-myPostfix","my-custom-header-1", "my-custom-header-2");
```
