### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <PackageVersion Include="Azure.Identity" Version="1.8.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="FluentValidation" Version="11.4.0" />
+    <PackageVersion Include="FluentValidation" Version="11.8.1" />
     <PackageVersion Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
     <PackageVersion Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageVersion Include="Kros.AspNetCore" Version="3.7.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,17 +22,17 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="5.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="6.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="Scrutor" Version="4.2.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="xunit" Version="2.6.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,37 +1,38 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
-    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
-    <PackageVersion Include="Azure.Identity" Version="1.8.0" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="8.0.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.10.4" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FluentValidation" Version="11.8.1" />
     <PackageVersion Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
     <PackageVersion Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageVersion Include="Kros.AspNetCore" Version="3.7.0" />
-    <PackageVersion Include="Kros.Utils" Version="2.0.0" />
-    <PackageVersion Include="MassTransit.AspNetCore" Version="7.1.8" />
-    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="7.1.8" />
+    <PackageVersion Include="Kros.Utils" Version="3.0.0" />
+    <PackageVersion Include="MassTransit.AspNetCore" Version="7.3.1" />
+    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.1.2" />
     <PackageVersion Include="MediatR" Version="12.2.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.11" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="5.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="6.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="Scrutor" Version="4.2.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageVersion Include="Scrutor" Version="4.2.2" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="xunit" Version="2.6.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Kros.Utils" Version="2.0.0" />
     <PackageVersion Include="MassTransit.AspNetCore" Version="7.1.8" />
     <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="7.1.8" />
-    <PackageVersion Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageVersion Include="MediatR" Version="12.2.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
     <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
     <PackageVersion Include="Azure.Identity" Version="1.8.0" />
-    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.8.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FluentValidation" Version="11.4.0" />
     <PackageVersion Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
     <PackageVersion Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
@@ -12,28 +12,28 @@
     <PackageVersion Include="Kros.Utils" Version="2.0.0" />
     <PackageVersion Include="MassTransit.AspNetCore" Version="7.1.8" />
     <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="7.1.8" />
-    <PackageVersion Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageVersion Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="5.2.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="6.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="NSubstitute" Version="4.4.0" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="Scrutor" Version="4.2.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="xunit" Version="2.6.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,40 +1,29 @@
 <Project>
-  <ItemGroup>
-    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
-    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="8.0.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.10.4" />
-    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="FluentValidation" Version="11.8.1" />
-    <PackageVersion Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
-    <PackageVersion Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
-    <PackageVersion Include="Kros.AspNetCore" Version="3.7.0" />
-    <PackageVersion Include="Kros.Utils" Version="3.0.0" />
-    <PackageVersion Include="MassTransit.AspNetCore" Version="7.3.1" />
-    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.1.2" />
-    <PackageVersion Include="MediatR" Version="12.2.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="Scrutor" Version="4.2.2" />
-    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageVersion Include="xunit" Version="2.6.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.5" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="8.0.0" />
+        <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
+        <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.1" />
+        <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+        <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+        <PackageVersion Include="FluentValidation" Version="11.8.1" />
+        <PackageVersion Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
+        <PackageVersion Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
+        <PackageVersion Include="Kros.AspNetCore" Version="3.7.0" />
+        <PackageVersion Include="Kros.Utils" Version="3.0.0" />
+        <PackageVersion Include="MassTransit.AspNetCore" Version="7.3.1" />
+        <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.1.2" />
+        <PackageVersion Include="MediatR" Version="12.2.0" />
+        <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+        <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+        <PackageVersion Include="NSubstitute" Version="5.1.0" />
+        <PackageVersion Include="Scrutor" Version="4.2.2" />
+        <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageVersion Include="xunit" Version="2.6.3" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.5" />
+    </ItemGroup>
 </Project>

--- a/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
+++ b/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
@@ -21,8 +21,6 @@
   <ItemGroup>
     <PackageReference Include="Kros.Utils" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
+++ b/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>2.3.0</Version>
     <Description>Extensions to facilitate work with Application Insights.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
+++ b/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Version>2.3.0</Version>
+    <TargetFramework>net8.0</TargetFramework>
+    <Version>3.0.0</Version>
     <Description>Extensions to facilitate work with Application Insights.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationHandler.cs
+++ b/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationHandler.cs
@@ -25,8 +25,7 @@ namespace Kros.AspNetCore.Authentication
         public ApiKeyBasicAuthenticationHandler(
             IOptionsMonitor<ApiKeyBasicAuthenticationOptions> options,
             ILoggerFactory logger,
-            UrlEncoder encoder,
-            ISystemClock clock) : base(options, logger, encoder, clock)
+            UrlEncoder encoder) : base(options, logger, encoder)
         {
         }
 

--- a/src/Kros.AspNetCore/Extensions/HttpClientExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/HttpClientExtensions.cs
@@ -108,11 +108,7 @@ namespace Kros.AspNetCore.Extensions
             Exception defaultException = null,
             CancellationToken cancellationToken = default)
             => await (await client.GetAndCheckResponseAsync(uri, defaultException, cancellationToken))
-#if NETCOREAPP3_1
-                .Content.ReadAsStringAsync();
-#else
                 .Content.ReadAsStringAsync(cancellationToken);
-#endif
 
         /// <summary>
         /// Get string response from http request and throws exception if request is unsuccessful.
@@ -127,11 +123,7 @@ namespace Kros.AspNetCore.Extensions
             Exception defaultException = null,
             CancellationToken cancellationToken = default)
             => await (await client.GetAndCheckResponseAsync(url, defaultException, cancellationToken))
-#if NETCOREAPP3_1
-                .Content.ReadAsStringAsync();
-#else
                 .Content.ReadAsStringAsync(cancellationToken);
-#endif
 
         /// <summary>
         /// Get stream response from http request and throws exception if request is unsuccessful.
@@ -146,11 +138,7 @@ namespace Kros.AspNetCore.Extensions
             Exception defaultException = null,
             CancellationToken cancellationToken = default)
             => await (await client.GetAndCheckResponseAsync(uri, defaultException, cancellationToken))
-#if NETCOREAPP3_1
-                .Content.ReadAsStreamAsync();
-#else
                 .Content.ReadAsStreamAsync(cancellationToken);
-#endif
 
         /// <summary>
         /// Get stream response from http request and throws exception if request is unsuccessful.
@@ -165,11 +153,7 @@ namespace Kros.AspNetCore.Extensions
             Exception defaultException = null,
             CancellationToken cancellationToken = default)
             => await (await client.GetAndCheckResponseAsync(url, defaultException, cancellationToken))
-#if NETCOREAPP3_1
-                .Content.ReadAsStreamAsync();
-#else
                 .Content.ReadAsStreamAsync(cancellationToken);
-#endif
 
         /// <summary>
         /// Get stream response from http request and throws exception if request is unsuccessful.
@@ -186,11 +170,7 @@ namespace Kros.AspNetCore.Extensions
             Exception defaultException = null,
             CancellationToken cancellationToken = default)
             => await (await client.GetAndCheckResponseAsync(uri, body, defaultException, cancellationToken))
-#if NETCOREAPP3_1
-                .Content.ReadAsStreamAsync();
-#else
                 .Content.ReadAsStreamAsync(cancellationToken);
-#endif
 
         /// <summary>
         /// Get stream response from http request and throws exception if request is unsuccessful.
@@ -207,11 +187,7 @@ namespace Kros.AspNetCore.Extensions
             Exception defaultException = null,
             CancellationToken cancellationToken = default)
             => await (await client.GetAndCheckResponseAsync(url, body, defaultException, cancellationToken))
-#if NETCOREAPP3_1
-                .Content.ReadAsStreamAsync();
-#else
                 .Content.ReadAsStreamAsync(cancellationToken);
-#endif
 
         /// <summary>
         /// Get byte array response from http request and throws exception if request is unsuccessful.
@@ -226,11 +202,7 @@ namespace Kros.AspNetCore.Extensions
             Exception defaultException = null,
             CancellationToken cancellationToken = default)
             => await (await client.GetAndCheckResponseAsync(uri, defaultException, cancellationToken))
-#if NETCOREAPP3_1
-                .Content.ReadAsByteArrayAsync();
-#else
                 .Content.ReadAsByteArrayAsync(cancellationToken);
-#endif
 
         /// <summary>
         /// Get byte array response from http request and throws exception if request is unsuccessful.
@@ -245,10 +217,6 @@ namespace Kros.AspNetCore.Extensions
             Exception defaultException = null,
             CancellationToken cancellationToken = default)
             => await (await client.GetAndCheckResponseAsync(url, defaultException, cancellationToken))
-#if NETCOREAPP3_1
-                .Content.ReadAsByteArrayAsync();
-#else
                 .Content.ReadAsByteArrayAsync(cancellationToken);
-#endif
     }
 }

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>3.7.0</Version>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -21,16 +21,10 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Uris" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" />
     <PackageReference Include="Kros.Utils" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Version>3.7.0</Version>
+    <TargetFramework>net8.0</TargetFramework>
+    <Version>4.0.0</Version>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Kros.MassTransit.Analyzers/Kros.MassTransit.Analyzers.csproj
+++ b/src/Kros.MassTransit.Analyzers/Kros.MassTransit.Analyzers.csproj
@@ -10,11 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 

--- a/src/Kros.MassTransit.Analyzers/Kros.MassTransit.Analyzers.csproj
+++ b/src/Kros.MassTransit.Analyzers/Kros.MassTransit.Analyzers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>2.0.0</Version>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/src/Kros.MassTransit.Analyzers/Kros.MassTransit.Analyzers.csproj
+++ b/src/Kros.MassTransit.Analyzers/Kros.MassTransit.Analyzers.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Version>2.0.0</Version>
+    <TargetFramework>net8.0</TargetFramework>
+    <Version>3.0.0</Version>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Kros.MassTransit.AzureServiceBus/AzureServiceBusOptions.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/AzureServiceBusOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Azure.ServiceBus;
+﻿using Azure.Messaging.ServiceBus;
+using System;
 using System.Collections.Generic;
 
 namespace Kros.MassTransit.AzureServiceBus
@@ -16,21 +17,7 @@ namespace Kros.MassTransit.AzureServiceBus
         /// <summary>
         /// Base service bus endpoint.
         /// </summary>
-        public string Endpoint
-        {
-            get
-            {
-                string endpoint = new ServiceBusConnectionStringBuilder(ConnectionString).Endpoint;
-                if (!string.IsNullOrEmpty(endpoint) && endpoint.EndsWith("/"))
-                {
-                    return endpoint;
-                }
-                else
-                {
-                    return endpoint + "/";
-                }
-            }
-        }
+        public Uri Endpoint => ServiceBusConnectionStringProperties.Parse(ConnectionString).Endpoint;
 
         /// <summary>
         /// Token time to live in seconds. If 0, default value <see cref=" ConfigDefaults.TokenTimeToLive"/> is used.

--- a/src/Kros.MassTransit.AzureServiceBus/AzureServiceBusOptions.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/AzureServiceBusOptions.cs
@@ -17,7 +17,22 @@ namespace Kros.MassTransit.AzureServiceBus
         /// <summary>
         /// Base service bus endpoint.
         /// </summary>
-        public string Endpoint => ServiceBusConnectionStringProperties.Parse(ConnectionString).Endpoint.ToString();
+        public string Endpoint
+        {
+            get
+            {
+                Uri endpointUri = ServiceBusConnectionStringProperties.Parse(ConnectionString).Endpoint;
+                string endpoint = endpointUri is null ? string.Empty : endpointUri.ToString();
+                if (!string.IsNullOrEmpty(endpoint) && endpoint.EndsWith('/'))
+                {
+                    return endpoint;
+                }
+                else
+                {
+                    return endpoint + "/";
+                }
+            }
+        }
 
         /// <summary>
         /// Token time to live in seconds.

--- a/src/Kros.MassTransit.AzureServiceBus/AzureServiceBusOptions.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/AzureServiceBusOptions.cs
@@ -20,8 +20,9 @@ namespace Kros.MassTransit.AzureServiceBus
         public Uri Endpoint => ServiceBusConnectionStringProperties.Parse(ConnectionString).Endpoint;
 
         /// <summary>
-        /// Token time to live in seconds. If 0, default value <see cref=" ConfigDefaults.TokenTimeToLive"/> is used.
+        /// Token time to live in seconds.
         /// </summary>
+        [Obsolete("This property is not used anymore.")]
         public int TokenTimeToLive { get; set; }
 
         /// <summary>

--- a/src/Kros.MassTransit.AzureServiceBus/AzureServiceBusOptions.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/AzureServiceBusOptions.cs
@@ -17,7 +17,7 @@ namespace Kros.MassTransit.AzureServiceBus
         /// <summary>
         /// Base service bus endpoint.
         /// </summary>
-        public Uri Endpoint => ServiceBusConnectionStringProperties.Parse(ConnectionString).Endpoint;
+        public string Endpoint => ServiceBusConnectionStringProperties.Parse(ConnectionString).Endpoint.ToString();
 
         /// <summary>
         /// Token time to live in seconds.

--- a/src/Kros.MassTransit.AzureServiceBus/ConfigDefaults.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/ConfigDefaults.cs
@@ -8,11 +8,6 @@ namespace Kros.MassTransit.AzureServiceBus
     public static class ConfigDefaults
     {
         /// <summary>
-        /// Default time to live for Azure service bus token.
-        /// </summary>
-        public static TimeSpan TokenTimeToLive { get; } = TimeSpan.FromMinutes(1);
-
-        /// <summary>
         /// Default message time to live in the queue.
         /// </summary>
         public static readonly TimeSpan MessageTimeToLive = TimeSpan.FromDays(14);

--- a/src/Kros.MassTransit.AzureServiceBus/Endpoints/Endpoint.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/Endpoints/Endpoint.cs
@@ -1,7 +1,5 @@
 ﻿using Kros.Utils;
 using MassTransit;
-using MassTransit.Azure.ServiceBus.Core;
-using MassTransit.ConsumeConfigurators;
 using System;
 
 namespace Kros.MassTransit.AzureServiceBus.Endpoints

--- a/src/Kros.MassTransit.AzureServiceBus/Endpoints/ReceiveEndpoint.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/Endpoints/ReceiveEndpoint.cs
@@ -1,6 +1,4 @@
 ﻿using MassTransit;
-using MassTransit.Azure.ServiceBus.Core;
-using MassTransit.ConsumeConfigurators;
 using System;
 using System.Collections.Generic;
 

--- a/src/Kros.MassTransit.AzureServiceBus/Endpoints/SubscriptionEndpoint.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/Endpoints/SubscriptionEndpoint.cs
@@ -1,6 +1,4 @@
 ﻿using MassTransit;
-using MassTransit.Azure.ServiceBus.Core;
-using MassTransit.ConsumeConfigurators;
 using System;
 using System.Collections.Generic;
 

--- a/src/Kros.MassTransit.AzureServiceBus/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/Extensions/ServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 cfg.AddBus(provider =>
                 {
-                    MassTransitForAzureBuilder builder = new(provider);
+                    MassTransitForAzureBuilder builder = new((IServiceProvider)provider);
                     busCfg?.Invoke(builder);
 
                     return builder.Build();

--- a/src/Kros.MassTransit.AzureServiceBus/Interfaces.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/Interfaces.cs
@@ -1,7 +1,4 @@
-﻿using GreenPipes.Configurators;
-using MassTransit;
-using MassTransit.Azure.ServiceBus.Core;
-using MassTransit.ConsumeConfigurators;
+﻿using MassTransit;
 using System;
 
 namespace Kros.MassTransit.AzureServiceBus

--- a/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
+++ b/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>2.3.0</Version>
     <Description>Simpler configuration of MassTransit library.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
+++ b/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Version>2.3.0</Version>
+    <TargetFramework>net8.0</TargetFramework>
+    <Version>3.0.0</Version>
     <Description>Simpler configuration of MassTransit library.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="Kros.Utils" />
-    <PackageReference Include="MassTransit.AspNetCore" />
     <PackageReference Include="MassTransit.Azure.ServiceBus.Core" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Scrutor" />

--- a/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
+++ b/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="MassTransit.Azure.ServiceBus.Core" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Scrutor" />
-    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
@@ -18,8 +18,6 @@ namespace Kros.MassTransit.AzureServiceBus
         #region Attributes
 
         private readonly string _connectionString;
-        private readonly TimeSpan _tokenTimeToLive;
-        private readonly IBusRegistrationContext _registrationContext;
         private readonly IServiceProvider _provider;
         private readonly string _topicNamePrefix;
         private readonly string _endpointNamePrefix;
@@ -36,7 +34,7 @@ namespace Kros.MassTransit.AzureServiceBus
         /// Ctor.
         /// </summary>
         /// <param name="connectionString">Connection string to Azure service bus.</param>
-        public MassTransitForAzureBuilder(string connectionString) : this(connectionString, ConfigDefaults.TokenTimeToLive)
+        public MassTransitForAzureBuilder(string connectionString) : this(connectionString, null)
         { }
 
         /// <summary>
@@ -44,8 +42,9 @@ namespace Kros.MassTransit.AzureServiceBus
         /// </summary>
         /// <param name="connectionString">Connection string to Azure service bus.</param>
         /// <param name="tokenTimeToLive">TTL for Azure service bus token.</param>
+        [Obsolete("'tokenTimeToLive' parameter is not used anymore. Use constructor without this parameter.")]
         public MassTransitForAzureBuilder(string connectionString, TimeSpan tokenTimeToLive) :
-            this(connectionString, tokenTimeToLive, null)
+            this(connectionString, null)
         { }
 
         /// <summary>
@@ -53,9 +52,11 @@ namespace Kros.MassTransit.AzureServiceBus
         /// </summary>
         /// <param name="connectionString">Connection string to Azure service bus.</param>
         /// <param name="provider">DI container.</param>
-        public MassTransitForAzureBuilder(string connectionString, IServiceProvider provider) :
-            this(connectionString, ConfigDefaults.TokenTimeToLive, provider)
-        { }
+        public MassTransitForAzureBuilder(string connectionString, IServiceProvider provider)
+        {
+            _connectionString = Check.NotNullOrWhiteSpace(connectionString, nameof(connectionString));
+            _provider = provider;
+        }
 
         /// <summary>
         /// Ctor.
@@ -67,9 +68,6 @@ namespace Kros.MassTransit.AzureServiceBus
 
             _connectionString = Check.NotNullOrWhiteSpace(options.ConnectionString,
                 nameof(AzureServiceBusOptions.ConnectionString));
-            _tokenTimeToLive = options.TokenTimeToLive > 0
-                ? TimeSpan.FromSeconds(options.TokenTimeToLive)
-                : ConfigDefaults.TokenTimeToLive;
             _provider = provider;
             _topicNamePrefix = options.TopicNamePrefix;
             _endpointNamePrefix = options.EndpointNamePrefix;
@@ -80,10 +78,10 @@ namespace Kros.MassTransit.AzureServiceBus
         /// Ctor.
         /// </summary>
         /// <param name="registrationContext">MassTransit registration context.</param>
+        [Obsolete("'registrationContext' is not used anymore. Use constructor with IServiceProvider paramter.")]
         public MassTransitForAzureBuilder(IBusRegistrationContext registrationContext)
             : this((IServiceProvider)registrationContext)
         {
-            _registrationContext = registrationContext;
         }
 
         /// <summary>
@@ -92,11 +90,10 @@ namespace Kros.MassTransit.AzureServiceBus
         /// <param name="connectionString">Connection string to Azure service bus.</param>
         /// <param name="tokenTimeToLive">TTL for Azure service bus token.</param>
         /// <param name="provider">DI container.</param>
+        [Obsolete("'tokenTimeToLive' parameter is not used anymore. Use constructor without this parameter.")]
         public MassTransitForAzureBuilder(string connectionString, TimeSpan tokenTimeToLive, IServiceProvider provider)
+            : this(connectionString, provider)
         {
-            _connectionString = Check.NotNullOrWhiteSpace(connectionString, nameof(connectionString));
-            _tokenTimeToLive = Check.GreaterThan(tokenTimeToLive, TimeSpan.Zero, nameof(tokenTimeToLive));
-            _provider = provider;
         }
 
         #endregion

--- a/src/Kros.MassTransit.AzureServiceBus/PrefixEntityNameFormatter.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/PrefixEntityNameFormatter.cs
@@ -1,12 +1,12 @@
 ﻿using Kros.Utils;
-using MassTransit.Topology;
+using MassTransit;
 
 namespace Kros.MassTransit.AzureServiceBus
 {
     /// <summary>
     /// Entity name formatter for MassTransit with prefixes.
     /// </summary>
-    class PrefixEntityNameFormatter: IEntityNameFormatter
+    class PrefixEntityNameFormatter : IEntityNameFormatter
     {
         private readonly IEntityNameFormatter _originalFormatter;
         private readonly string _prefix;

--- a/src/Kros.MediatR.Extensions/Kros.MediatR.Extensions.csproj
+++ b/src/Kros.MediatR.Extensions/Kros.MediatR.Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>2.3.0</Version>
     <Description>Extensions and helpers to facilitate work with MediatR library.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Kros.MediatR.Extensions/Kros.MediatR.Extensions.csproj
+++ b/src/Kros.MediatR.Extensions/Kros.MediatR.Extensions.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Version>2.3.0</Version>
+    <TargetFramework>net8.0</TargetFramework>
+    <Version>3.0.0</Version>
     <Description>Extensions and helpers to facilitate work with MediatR library.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Kros.AspNetCore" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" />
+    <PackageReference Include="MediatR" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kros.ProblemDetails.Extensions/Kros.ProblemDetails.Extensions.csproj
+++ b/src/Kros.ProblemDetails.Extensions/Kros.ProblemDetails.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>2.3.0</Version>
     <Description>Simple extensions for ProblemDetails.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Kros.ProblemDetails.Extensions/Kros.ProblemDetails.Extensions.csproj
+++ b/src/Kros.ProblemDetails.Extensions/Kros.ProblemDetails.Extensions.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Version>2.3.0</Version>
+    <TargetFramework>net8.0</TargetFramework>
+    <Version>3.0.0</Version>
     <Description>Simple extensions for ProblemDetails.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Kros.ProblemDetails.Extensions/ProblemDetailsExtensions.cs
+++ b/src/Kros.ProblemDetails.Extensions/ProblemDetailsExtensions.cs
@@ -21,7 +21,7 @@ namespace Kros.ProblemDetails.Extensions
         /// <param name="configAction">Additional action for configuring Hellang problem details.</param>
         public static IServiceCollection AddKrosProblemDetails(
             this IServiceCollection services,
-            Action<ProblemDetailsOptions> configAction = null)
+            Action<Hellang.Middleware.ProblemDetails.ProblemDetailsOptions> configAction = null)
             => services.AddProblemDetails(p =>
             {
                 p.IncludeExceptionDetails = (context, ex) => IncludeExceptionDetails(context, ex);

--- a/src/Kros.Swagger.Extensions/Filters/ClassNameAsTitleSchemaFilter.cs
+++ b/src/Kros.Swagger.Extensions/Filters/ClassNameAsTitleSchemaFilter.cs
@@ -23,7 +23,7 @@ namespace Kros.Swagger.Extensions.Filters
             {
                 return true;
             }
-            Type nullableType = Nullable.GetUnderlyingType(type);
+            Type? nullableType = Nullable.GetUnderlyingType(type);
             if (nullableType != null)
             {
                 return nullableType.IsPrimitive || nullableType == typeof(string);

--- a/src/Kros.Swagger.Extensions/Filters/StringEnumFilter.cs
+++ b/src/Kros.Swagger.Extensions/Filters/StringEnumFilter.cs
@@ -212,7 +212,7 @@ namespace Kros.Swagger.Extensions.Filters
         private static string CreateNotEnumTypeMessage(Type type)
         {
             string typeName = type.Name;
-            string typeFullName = type.FullName;
+            string? typeFullName = type.FullName;
             return $"{nameof(StringEnumFilter)} can be used only with Enum types. "
                 + $"The type {typeName} ({typeFullName}) is not an enum.";
         }
@@ -266,16 +266,22 @@ namespace Kros.Swagger.Extensions.Filters
 
         private string GetXmlSummaryForEnumMember(string enumMemberName)
         {
+            static bool FindElementByNameAttribute(XElement el, string value)
+            {
+                XAttribute? attribute = el.Attribute("name");
+                return (attribute is not null) && attribute.Value.Equals(value, StringComparison.OrdinalIgnoreCase);
+            }
+
             string enumMemberSummary = "";
             foreach (XDocument xmlDoc in _xmlDocs)
             {
-                XElement enumMemberComments = xmlDoc.Descendants("member")
-                    .FirstOrDefault(m => m.Attribute("name").Value.Equals(enumMemberName, StringComparison.OrdinalIgnoreCase));
+                XElement? enumMemberComments = xmlDoc.Descendants("member")
+                    .FirstOrDefault(m => FindElementByNameAttribute(m, enumMemberName));
                 if (enumMemberComments == null)
                 {
                     continue;
                 }
-                XElement summary = enumMemberComments.Descendants("summary").FirstOrDefault();
+                XElement? summary = enumMemberComments.Descendants("summary").FirstOrDefault();
                 if (summary == null)
                 {
                     continue;

--- a/src/Kros.Swagger.Extensions/Kros.Swagger.Extensions.csproj
+++ b/src/Kros.Swagger.Extensions/Kros.Swagger.Extensions.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 

--- a/src/Kros.Swagger.Extensions/Kros.Swagger.Extensions.csproj
+++ b/src/Kros.Swagger.Extensions/Kros.Swagger.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>2.4.0</Version>
     <Description>Extensions to facilitate work with Swagger documentation.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Kros.Swagger.Extensions/Kros.Swagger.Extensions.csproj
+++ b/src/Kros.Swagger.Extensions/Kros.Swagger.Extensions.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Version>2.4.0</Version>
+    <TargetFramework>net8.0</TargetFramework>
+    <Version>3.0.0</Version>
     <Description>Extensions to facilitate work with Swagger documentation.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
@@ -37,6 +37,13 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Kros.Swagger.Extensions/SwaggerExtensions.cs
+++ b/src/Kros.Swagger.Extensions/SwaggerExtensions.cs
@@ -46,7 +46,7 @@ namespace Kros.Swagger.Extensions
             services.ConfigureSwaggerGen(options =>
             {
                 // '+' (nested classes) is not valid character in OpenApi reference.
-                options.CustomSchemaIds(x => x.FullName.Replace("+", "-"));
+                options.CustomSchemaIds(x => x.FullName?.Replace("+", "-"));
             });
 
             services.AddSwaggerGen(c =>
@@ -79,7 +79,7 @@ namespace Kros.Swagger.Extensions
 
         private static void AddSwaggerSecurity(SwaggerGenOptions swaggerOptions, OpenApiInfo swaggerDocumentationSettings)
         {
-            if (swaggerDocumentationSettings.Extensions.TryGetValue("TokenUrl", out IOpenApiExtension t) &&
+            if (swaggerDocumentationSettings.Extensions.TryGetValue("TokenUrl", out IOpenApiExtension? t) &&
                 t is OpenApiString tokenUrl)
             {
                 swaggerOptions.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
@@ -89,7 +89,7 @@ namespace Kros.Swagger.Extensions
                     {
                         Password = new OpenApiOAuthFlow()
                         {
-                            TokenUrl = new Uri(tokenUrl?.Value)
+                            TokenUrl = new Uri(tokenUrl.Value)
                         }
                     }
                 });
@@ -163,10 +163,10 @@ namespace Kros.Swagger.Extensions
 
         private static string? GetOAuthClientId(OpenApiInfo swaggerDocumentationSettings)
         {
-            if (swaggerDocumentationSettings.Extensions.TryGetValue("OAuthClientId", out IOpenApiExtension c) &&
+            if (swaggerDocumentationSettings.Extensions.TryGetValue("OAuthClientId", out IOpenApiExtension? c) &&
                 c is OpenApiString clientId)
             {
-                return clientId?.Value;
+                return clientId.Value;
             }
 
             return DefaultOAuthClientId;

--- a/tests/Kros.ApplicationInsights.Extensions.Tests/Kros.ApplicationInsights.Extensions.Tests.csproj
+++ b/tests/Kros.ApplicationInsights.Extensions.Tests/Kros.ApplicationInsights.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Kros.AspNetCore.Tests/Authentication/ApiKeyBasicAuthenticationHandlerShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authentication/ApiKeyBasicAuthenticationHandlerShould.cs
@@ -55,7 +55,7 @@ namespace Kros.AspNetCore.Tests.Authentication
         public async Task NotProcessRequestsWithoutBasicAuthHeader()
         {
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "Bearer key2");
+            context.Request.Headers[HeaderNames.Authorization] = "Bearer key2";
             await _handler.InitializeAsync(
                 new AuthenticationScheme(_options.Scheme, null, typeof(ApiKeyBasicAuthenticationHandler)),
                 context);
@@ -69,7 +69,7 @@ namespace Kros.AspNetCore.Tests.Authentication
         public async Task RejectRequestsWithIncorrectApiKey()
         {
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "Basic wrong_key");
+            context.Request.Headers[HeaderNames.Authorization] = "Basic wrong_key";
             await _handler.InitializeAsync(
                 new AuthenticationScheme(_options.Scheme, null, typeof(ApiKeyBasicAuthenticationHandler)),
                 context);
@@ -83,7 +83,7 @@ namespace Kros.AspNetCore.Tests.Authentication
         public async Task AcceptRequestsWithCorrectApiKey()
         {
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "Basic key2");
+            context.Request.Headers[HeaderNames.Authorization] = "Basic key2";
             await _handler.InitializeAsync(
                 new AuthenticationScheme(_options.Scheme, null, typeof(ApiKeyBasicAuthenticationHandler)),
                 context);

--- a/tests/Kros.AspNetCore.Tests/Authentication/ApiKeyBasicAuthenticationHandlerShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authentication/ApiKeyBasicAuthenticationHandlerShould.cs
@@ -33,9 +33,7 @@ namespace Kros.AspNetCore.Tests.Authentication
             _handler = new ApiKeyBasicAuthenticationHandler(
                 _optionsMonitor,
                 _loggerFactory,
-                Substitute.For<UrlEncoder>(),
-                Substitute.For<ISystemClock>()
-                );
+                Substitute.For<UrlEncoder>());
         }
 
         [Fact]

--- a/tests/Kros.AspNetCore.Tests/Authorization/ClientCredentialsAuthorizationMiddlewareShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/ClientCredentialsAuthorizationMiddlewareShould.cs
@@ -41,7 +41,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             HttpContext context = new DefaultHttpContext();
             if (authHeader != null)
             {
-                context.Request.Headers.Add(HeaderNames.Authorization, authHeader);
+                context.Request.Headers[HeaderNames.Authorization] = authHeader;
             }
             return context;
         }

--- a/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/GatewayAuthorizationMiddlewareShould.cs
@@ -30,7 +30,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             (IHttpClientFactory httpClientFactoryMock, GatewayAuthorizationMiddleware middleware) = CreateMiddleware(HttpStatusCode.OK);
 
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
             await middleware.Invoke(context, httpClientFactoryMock, new MemoryCache(new MemoryCacheOptions()), CreateProvider());
 
             context.Request.Headers[HeaderNames.Authorization]
@@ -49,8 +49,8 @@ namespace Kros.AspNetCore.Tests.Authorization
                 = CreateMiddlewareForForwardedHeaders(HttpStatusCode.OK, forwardedHeaders);
 
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
-            context.Request.Headers.Add("ApplicationType", "25");
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
+            context.Request.Headers["ApplicationType"] = "25";
             await middleware.Invoke(context, httpClientFactoryMock, new MemoryCache(new MemoryCacheOptions()), CreateProvider());
 
             htttpClient.DefaultRequestHeaders.GetValues("ApplicationType").Should().Equal("25");
@@ -65,8 +65,8 @@ namespace Kros.AspNetCore.Tests.Authorization
                 = CreateMiddlewareForForwardedHeaders(HttpStatusCode.OK, forwardedHeaders);
 
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
-            context.Request.Headers.Add("ApplicationType", "25");
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
+            context.Request.Headers["ApplicationType"] = "25";
             await middleware.Invoke(context, httpClientFactoryMock, new MemoryCache(new MemoryCacheOptions()), CreateProvider());
 
             htttpClient.DefaultRequestHeaders.TryGetValues("ApplicationType", out IEnumerable<string> _).Should().BeFalse();
@@ -86,7 +86,7 @@ namespace Kros.AspNetCore.Tests.Authorization
                 });
 
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
             await middleware.Invoke(context, httpClientFactoryMock, new MemoryCache(new MemoryCacheOptions()), CreateProvider());
 
             context.Request.Headers[HeaderNames.Authorization]
@@ -147,7 +147,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             (IHttpClientFactory httpClientFactoryMock, GatewayAuthorizationMiddleware middleware) = CreateMiddleware(HttpStatusCode.OK);
 
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
             context.Request.Query = new QueryCollection(QueryHelpers.ParseQuery("?hash=asdf"));
             await middleware.Invoke(context, httpClientFactoryMock, new MemoryCache(new MemoryCacheOptions()), CreateProvider());
 
@@ -168,7 +168,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             MemoryCache cache = new(new MemoryCacheOptions());
             cache.Set(HashCode.Combine(accessToken), "AAAAAA");
 
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
             await middleware.Invoke(context, httpClientFactoryMock, cache, CreateProvider());
 
             context.Request.Headers[HeaderNames.Authorization]
@@ -207,7 +207,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             DefaultHttpContext context = new();
             MemoryCache cache = new(new MemoryCacheOptions());
 
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
             await middleware.Invoke(context, httpClientFactoryMock, cache, CreateProvider());
 
             cache.Get(HashCode.Combine(accessToken))
@@ -242,7 +242,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             DefaultHttpContext context = new();
             MemoryCache cache = new(new MemoryCacheOptions());
 
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
             context.Request.Path = "/ignoredPath/";
             context.Request.Method = HttpMethod.Get.ToString();
             await middleware.Invoke(context, httpClientFactoryMock, cache, CreateProvider());
@@ -272,7 +272,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             (IHttpClientFactory httpClientFactoryMock, GatewayAuthorizationMiddleware middleware) = CreateMiddleware(statusCode);
 
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
 
             await Assert.ThrowsAsync<UnauthorizedAccessException>(()
                 => middleware.Invoke(
@@ -306,7 +306,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             (IHttpClientFactory httpClientFactoryMock, GatewayAuthorizationMiddleware middleware) = CreateMiddleware(HttpStatusCode.Forbidden);
 
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
 
             await Assert.ThrowsAsync<ResourceIsForbiddenException>(()
                 => middleware.Invoke(
@@ -322,7 +322,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             (IHttpClientFactory httpClientFactoryMock, GatewayAuthorizationMiddleware middleware) = CreateMiddleware(HttpStatusCode.NotFound);
 
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
 
             await Assert.ThrowsAsync<NotFoundException>(()
                 => middleware.Invoke(
@@ -338,7 +338,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             (IHttpClientFactory httpClientFactoryMock, GatewayAuthorizationMiddleware middleware) = CreateMiddleware(HttpStatusCode.BadRequest);
 
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
 
             await Assert.ThrowsAsync<BadRequestException>(()
                 => middleware.Invoke(
@@ -366,9 +366,9 @@ namespace Kros.AspNetCore.Tests.Authorization
                 });
 
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, "access_token");
-            context.Request.Headers.Add("Connection-Id", connectionId);
-            context.Request.Headers.Add("any-header", connectionId);
+            context.Request.Headers[HeaderNames.Authorization] = "access_token";
+            context.Request.Headers["Connection-Id"] = connectionId;
+            context.Request.Headers["any-header"] = connectionId;
             await middleware.Invoke(context, httpClientFactoryMock, new MemoryCache(new MemoryCacheOptions()), CreateProvider());
 
             context.Request.Headers[HeaderNames.Authorization]
@@ -396,9 +396,9 @@ namespace Kros.AspNetCore.Tests.Authorization
                 });
             const string accessToken = "access_token";
             DefaultHttpContext context = new();
-            context.Request.Headers.Add(HeaderNames.Authorization, accessToken);
-            context.Request.Headers.Add("Connection-Id", connectionId);
-            context.Request.Headers.Add("any-header", connectionId);
+            context.Request.Headers[HeaderNames.Authorization] = accessToken;
+            context.Request.Headers["Connection-Id"] = connectionId;
+            context.Request.Headers["any-header"] = connectionId;
 
             int key = connectionId == null
                 ? GatewayAuthorizationMiddleware.GetKey(accessToken)

--- a/tests/Kros.AspNetCore.Tests/Authorization/JwtAuthorizationHelperShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/JwtAuthorizationHelperShould.cs
@@ -67,7 +67,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             string expectedToken)
         {
             IHeaderDictionary headers = new HeaderDictionary();
-            headers.Add(HeaderNames.Authorization, token);
+            headers[HeaderNames.Authorization] = token;
             bool contains = JwtAuthorizationHelper.TryGetTokenValue(headers, out token, removePrefix);
             contains.Should().Be(expectedContains);
             token.Should().Be(expectedToken);

--- a/tests/Kros.AspNetCore.Tests/Authorization/JwtBearerClaimsMiddlewareShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authorization/JwtBearerClaimsMiddlewareShould.cs
@@ -73,7 +73,7 @@ namespace Kros.AspNetCore.Tests.Authorization
             HttpContext context = new DefaultHttpContext();
             if (authHeader != null)
             {
-                context.Request.Headers.Add(HeaderNames.Authorization, authHeader);
+                context.Request.Headers[HeaderNames.Authorization] = authHeader;
             }
             return context;
         }

--- a/tests/Kros.AspNetCore.Tests/Kros.AspNetCore.Tests.csproj
+++ b/tests/Kros.AspNetCore.Tests/Kros.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Kros.AspNetCore.Tests/Kros.AspNetCore.Tests.csproj
+++ b/tests/Kros.AspNetCore.Tests/Kros.AspNetCore.Tests.csproj
@@ -11,9 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />

--- a/tests/Kros.MediatR.Extensions.Tests/ControllerBaseExtensionsShould.cs
+++ b/tests/Kros.MediatR.Extensions.Tests/ControllerBaseExtensionsShould.cs
@@ -69,7 +69,7 @@ namespace Kros.MediatR.Extensions.Tests
         private static TestController CreateController()
         {
             ServiceCollection service = new();
-            service.AddMediatR(Assembly.GetExecutingAssembly());
+            service.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
             service.AddMediatRNullCheckPostProcessor();
 
             ActionContext actionContext = new()

--- a/tests/Kros.MediatR.Extensions.Tests/Kros.MediatR.Extensions.Tests.csproj
+++ b/tests/Kros.MediatR.Extensions.Tests/Kros.MediatR.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Kros.MediatR.Extensions.Tests/Kros.MediatR.Extensions.Tests.csproj
+++ b/tests/Kros.MediatR.Extensions.Tests/Kros.MediatR.Extensions.Tests.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/tests/Kros.MediatR.Extensions.Tests/Kros.MediatR.Extensions.Tests.csproj
+++ b/tests/Kros.MediatR.Extensions.Tests/Kros.MediatR.Extensions.Tests.csproj
@@ -7,9 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/Kros.MediatR.Extensions.Tests/ServiceCollectionExtensionsShould.cs
+++ b/tests/Kros.MediatR.Extensions.Tests/ServiceCollectionExtensionsShould.cs
@@ -100,7 +100,7 @@ namespace Kros.MediatR.Extensions.Tests
 
         public interface ICommandRequest { }
 
-        public class TestCommand : IRequest, ICommandRequest
+        public class TestCommand : IRequest<Unit>, ICommandRequest
         {
         }
 


### PR DESCRIPTION
- All projects are upgraded to .NET 8.
- _MediatR_ and _ProblemDetails_ projects will have second round, because they depend on Kros.AspNetCore.
- _MassTransit_ project has some obsolete warnings. It will need deeper refactoring to use new MassTransit library.