### PR TITLE
Fix System.ArgumentNullException at startup

### DIFF
--- a/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
+++ b/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <Description>Simpler configuration of MassTransit library.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
+++ b/src/Kros.MassTransit.AzureServiceBus/MassTransitForAzureBuilder.cs
@@ -222,16 +222,7 @@ namespace Kros.MassTransit.AzureServiceBus
         /// <param name="busCfg">Service bus configuration.</param>
         /// <returns>Service bus host.</returns>
         private void CreateServiceHost(IServiceBusBusFactoryConfigurator busCfg)
-        {
-            var cstrBuilder = ServiceBusConnectionStringProperties.Parse(_connectionString);
-            busCfg.Host(_connectionString, hostCfg =>
-            {
-                hostCfg.SharedAccessSignature(sasCfg =>
-                {
-                    sasCfg.SasCredential = new AzureSasCredential(cstrBuilder.SharedAccessSignature);
-                });
-            });
-        }
+            => busCfg.Host(_connectionString);
 
         /// <summary>
         /// Configures service bus.


### PR DESCRIPTION
The standard connection string format:

```
Endpoint=sb://some-sb.servicebus.windows.net/;SharedAccessKeyName=abc;SharedAccessKey=topSecretPaswordKey
```
doesn't contain a pre-configured SaS (Shared Access Signature) token. This caused the service bus initialization to fail on startup with the following error:
```
System.ArgumentNullException : Value cannot be null. (Parameter 'signature')
Stack Trace:
Argument.AssertNotNullOrWhiteSpace(String value, String name)
AzureSasCredential.ctor(String signature)
<>c__DisplayClass24_0.<CreateServiceHost>b__1(ISharedAccessSignatureTokenProviderConfigurator sasCfg)
ServiceBusBusFactoryConfiguratorExtensions.SharedAccessSignature(IServiceBusHostConfigurator configurator, Action`1 configure) line 80
<>c__DisplayClass24_0.<CreateServiceHost>b__0(IServiceBusHostConfigurator hostCfg)
ServiceBusBusFactoryConfiguratorExtensions.Host(IServiceBusBusFactoryConfigurator configurator, String connectionString, Action`1 configure) line 69
MassTransitForAzureBuilder.CreateServiceHost(IServiceBusBusFactoryConfigurator busCfg)
MassTransitForAzureBuilder.<Build>b__23_0(IServiceBusBusFactoryConfigurator busCfg)
AzureBusFactory.CreateUsingServiceBus(Action`1 configure) line 27
ServiceBusConfigurationExtensions.CreateUsingAzureServiceBus(IBusFactorySelector selector, Action`1 configure) line 21
...
```
A working solution instead of using SasCredentials also could be:
```
hostCfg.NamedKeyCredential = new AzureNamedKeyCredential(cstrBuilder.SharedAccessKeyName, cstrBuilder.SharedAccessKey);
```

However, explicitly defining the credential seems unnecessary as the provided connection string handles it automatically.