### PR TITLE
Return IEndpointConventionBuilder from extension

### DIFF
--- a/src/Kros.AspNetCore/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/Kros.AspNetCore/Extensions/EndpointRouteBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace Kros.AspNetCore.Extensions
         /// <exception cref="InvalidOperationException">
         /// When `HttpConnectionDispatcher` section is missing in configuration.
         /// </exception>
-        public static void MapSignalRHubWithOptions<THub>(
+        public static IHubEndpointConventionBuilder MapSignalRHubWithOptions<THub>(
             this IEndpointRouteBuilder endpoints,
             IConfiguration configuration,
             [StringSyntax("Route")] string pattern)  where THub : Hub
@@ -37,7 +37,7 @@ namespace Kros.AspNetCore.Extensions
                         Helpers.GetSectionName<HttpConnectionDispatcherOptions>()));
             }
 
-            endpoints.MapHub<THub>(pattern, o =>
+            return endpoints.MapHub<THub>(pattern, o =>
             {
                 o = options;
             });

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>4.1.0</Version>
+    <Version>4.1.1</Version>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>


### PR DESCRIPTION
For better usage, return IEndpointConventionBuilder, so signalr is configurable better

