### PR TITLE
Support authorization in Swagger documentation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageVersion Include="xunit" Version="2.6.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>

--- a/src/Kros.Swagger.Extensions/AllowAnonymousOperationFilter.cs
+++ b/src/Kros.Swagger.Extensions/AllowAnonymousOperationFilter.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Linq;
+
+namespace Kros.Swagger.Extensions
+{
+    /// <summary>
+    /// Filter for allowing anonymous access to operations.
+    /// This filter is suitable, if by default all your endpoints are authorized and you want just for some of them
+    /// to allow anonymous access. It clears any security requirements from operation if the operation
+    /// has <see cref="AllowAnonymousAttribute"/> and sets security requirements for all other operations.
+    /// </summary>
+    internal class AllowAnonymousOperationFilter : IOperationFilter
+    {
+        private readonly IConfiguration _configuration;
+
+        public AllowAnonymousOperationFilter(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        /// <inheritdoc/>
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            SwaggerSettings? settings = _configuration.GetSwaggerSettings();
+            if (settings is not null)
+            {
+                bool hasClassAttribute = context.MethodInfo.DeclaringType is null
+                    ? false
+                    : context.MethodInfo.DeclaringType.GetCustomAttributes(true).OfType<AllowAnonymousAttribute>().Any();
+                bool hasMethodAttribute = context.MethodInfo.GetCustomAttributes(true).OfType<AllowAnonymousAttribute>().Any();
+                bool hasMetadataAttribute = context.ApiDescription.ActionDescriptor.EndpointMetadata.OfType<IAllowAnonymous>().Any();
+
+                operation.Security = hasClassAttribute || hasMethodAttribute || hasMetadataAttribute
+                    ? []
+                    : settings.CreateSecurityRequirements();
+            }
+        }
+    }
+}

--- a/src/Kros.Swagger.Extensions/AuthorizeOperationFilter.cs
+++ b/src/Kros.Swagger.Extensions/AuthorizeOperationFilter.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Linq;
+
+namespace Kros.Swagger.Extensions
+{
+    /// <summary>
+    /// Filter for allowing authorized access to operations.
+    /// This filter is suitable, if by default all your endpoints allow anonymous access and you want just for some of them
+    /// to be authorized. It sets security requirements for all operations which have <see cref="AuthorizeAttribute"/>
+    /// and clears any security requirements from all other operations.
+    /// </summary>
+    internal class AuthorizeOperationFilter : IOperationFilter
+    {
+        private readonly IConfiguration _configuration;
+
+        public AuthorizeOperationFilter(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        /// <inheritdoc/>
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            SwaggerSettings? settings = _configuration.GetSwaggerSettings();
+            if (settings is not null)
+            {
+                bool hasClassAttribute = context.MethodInfo.DeclaringType is null
+                    ? false
+                    : context.MethodInfo.DeclaringType.GetCustomAttributes(true).OfType<AuthorizeAttribute>().Any();
+                bool hasMethodAttribute = context.MethodInfo.GetCustomAttributes(true).OfType<AuthorizeAttribute>().Any();
+                bool hasMetadataAttribute = context.ApiDescription.ActionDescriptor.EndpointMetadata.OfType<IAuthorizeData>().Any();
+
+                operation.Security = hasClassAttribute || hasMethodAttribute || hasMetadataAttribute
+                    ? settings.CreateSecurityRequirements()
+                    : [];
+            }
+        }
+    }
+}

--- a/src/Kros.Swagger.Extensions/Kros.Swagger.Extensions.csproj
+++ b/src/Kros.Swagger.Extensions/Kros.Swagger.Extensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <Description>Extensions to facilitate work with Swagger documentation.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>

--- a/src/Kros.Swagger.Extensions/README.md
+++ b/src/Kros.Swagger.Extensions/README.md
@@ -1,49 +1,124 @@
 # Kros.Swagger.Extensions
 
-**Kros.Swagger.Extensions** je pomocná knižnica pre zjednodušenie práce so Swagger dokumentáciou.
-
-> Swagger slúži na dokumentovanie API rozhrania.
+**Kros.Swagger.Extensions** is helper library for easier work with Swagger documentation.
 
 ## Extensions
 
-Menný priestor `Kros.Swagger.Extensions` obsahuje rozšírenia pre Swagger.
+`Kros.Swagger.Extensions` namespace contains extensions for Swagger.
 
-Registrovaním `services.AddSwaggerDocumentation(Configuration)` pridáte do pipeline-y Swagger, ktorý prejde všetky verejné API a vytvorí z nich dokumentáciu.
+There are two steps that need to be done to add Swagger documentation to your application.
 
-```CSharp
-public virtual void ConfigureServices(IServiceCollection services)
-{
-	services.AddSwaggerDocumentation(Configuration);
-}
-```
+- Register services by calling `builder.Services.AddSwaggerDocumentation(builder.Configuration)`.
+- Add middleware by calling `app.UseSwaggerDocumentation(app.Configuration)`.
 
-Ďalej je potrebné pridať middleware zavolaním `app.UseSwaggerDocumentation(Configuration)` v metóde `Configure`.
-
-```CSharp
-public virtual void Configure(IApplicationBuilder app, IHostingEnvironment env)
-{
-    app.UseSwaggerDocumentation(Configuration);
-}
-```
-
-Swagger dokumentáciu je možné konfigurovať v `appSettings.json` súbore.
-
-Príklad konfigurácie:
+Swagger can be configured in `appsettings.json` in `SwaggerDocumentation` section.
 
 ```json
 "SwaggerDocumentation": {
-  "Version": "v1",
-  "Title": "Project Service Api",
-  "Description": "Web API for SSW.",
-  "Contact": {
-    "Name": "Kros",
-    "Email": "info@kros.sk",
-    "Url": "www.kros.sk"
-  },
-  "Extensions": {
-    "TokenUrl": "https://login.site.com/token",
-    "OAuthClientId": "kros_postman"
-  }
+    "version": "1.0",
+    "title": "Payrolls API",
+    "description": "KROS Payrolls service API.",
+    "contact": {
+        "name": "KROS a.s.",
+        "email": "info@example.com",
+        "url": "https://www.example.com"
+    }
 }
 ```
 
+Library supports authorization in Swagger, read more in examples.
+
+## Examples
+
+### Simple usage
+
+```csharp
+builder.Services.AddSwaggerDocumentation(builder.Configuration);
+
+...
+
+if (app.Environment.IsTestOrDevelopment())
+{
+    app.UseSwaggerDocumentation(app.Configuration);
+}
+```
+
+### Fine grained configuration
+
+```csharp
+builder.Services.AddSwaggerDocumentation(builder.Configuration, config =>
+{
+    // Use 'config' object to configure Swagger.
+    // This is standard Swagger configuration when using Swagger directly by 'services.AddSwaggerGen()'.
+});
+
+...
+
+if (app.Environment.IsTestOrDevelopment())
+{
+    app.UseSwaggerDocumentation(app.Configuration,
+        setupAction: config =>{
+          // Use 'config' object to configure Swagger.
+          // This is standard Swagger configuration when using Swagger directly by 'app.UseSwagger'.
+        },
+        setupUiAction: configUi =>
+        {
+          // Use 'config' object to configure Swagger UI.
+          // This is standard Swagger configuration when using Swagger UI directly by 'app.UseSwaggerUI'.
+        }
+    );
+}
+```
+
+### Authorization
+
+To declaratively configure authorization, use `authorizations` property in configuration.
+This is an object property, where keys in it are arbitrary name for the authorization.
+The authorization configuration the is just `OpenApiSecurityScheme` object. It must have authorization `type`
+defined and at least one `flow`.
+
+```json
+"SwaggerDocumentation": {
+    "version": "1.0",
+    "title": "Payrolls API",
+    "description": "KROS Payrolls service API.",
+    "authorizations": {
+        "loginWtf": {
+            "type": "oauth2",
+            "flows": {
+                "password": {
+                    "tokenUrl": "https://login.kros.wtf/connect/token",
+                    "scopes": {
+                        "Kros.Payrolls": "Human description of the scope."
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+To correctly authorize endpoints in Swagger (called operations), the must have correct _security requirement_
+defined. There are two confiruration extension methods available for this purpose.
+
+**If by default all your endpoints are authorized**, and only some of them allows anonymous access,
+use `ClearSecurityRequirementsFromAnonymousEndpoints` when configurion Swagger services.
+This clears security requirements for all endpoints which are marked as anonymous (`AllowAnonymous` attribute),
+and sets security requirements for all other endpoints.
+
+**If by default all your endpoints are public**, and only some of them are authorized,
+use `SetSecurityRequirementsToAuthorizedEndpoints` when configurion Swagger services.
+This sets security requirements for all endpoints which are marked as authorized (`Authorize` attribute),
+and clears security requirements for all other endpoints.
+
+This extensions work for both, standard attributes and extension methods in minimal API.
+
+```csharp
+builder.Services.AddSwaggerDocumentation(builder.Configuration, config =>
+{
+    config.ClearSecurityRequirementsFromAnonymousEndpoints();
+});
+```
+
+> Although the library supports multiple authorizations with multiple flows in configuration,
+> this has not been tested.

--- a/src/Kros.Swagger.Extensions/SwaggerExtensions.cs
+++ b/src/Kros.Swagger.Extensions/SwaggerExtensions.cs
@@ -1,14 +1,13 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Swashbuckle.AspNetCore.SwaggerUI;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Kros.Swagger.Extensions
 {
@@ -18,7 +17,6 @@ namespace Kros.Swagger.Extensions
     public static class SwaggerExtensions
     {
         private const string SwaggerDocumentationSectionName = "SwaggerDocumentation";
-        private const string DefaultOAuthClientId = "kros_postman";
 
         /// <summary>
         /// Registers Swagger documentation generator to IoC container.
@@ -48,13 +46,13 @@ namespace Kros.Swagger.Extensions
             {
                 if (settings is not null)
                 {
-                    c.SwaggerDoc(settings.Version, MapSwaggerSettingsToOpenApiInfo(settings));
+                    c.SwaggerDoc(settings.Version, settings);
+                    AddAuthorization(c, settings);
                 }
                 if (includeXmlcomments)
                 {
                     c.IncludeXmlCommentsFromAllFilesInCurrentDomainBaseDirectory();
                 }
-                //AddSwaggerSecurity(c, options);
                 c.UseClassNameAsTitle();
                 c.UseNullableSchemaFilter();
                 setupAction?.Invoke(c);
@@ -74,77 +72,6 @@ namespace Kros.Swagger.Extensions
             IConfiguration configuration,
             Action<SwaggerGenOptions>? setupAction = null)
             => AddSwaggerDocumentation(services, configuration, false, setupAction);
-
-        private static void AddSwaggerSecurity(SwaggerGenOptions swaggerOptions, OpenApiInfo swaggerDocumentationSettings)
-        {
-            if (swaggerDocumentationSettings.Extensions.TryGetValue("TokenUrl", out IOpenApiExtension? t) &&
-                t is OpenApiString tokenUrl)
-            {
-                swaggerOptions.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
-                {
-                    Type = SecuritySchemeType.OAuth2,
-                    Flows = new OpenApiOAuthFlows()
-                    {
-                        Password = new OpenApiOAuthFlow()
-                        {
-                            TokenUrl = new Uri(tokenUrl.Value)
-                        }
-                    }
-                });
-                swaggerOptions.AddSecurityRequirement(new OpenApiSecurityRequirement()
-                {
-                    {
-                        new OpenApiSecurityScheme
-                        {
-                            Reference = new OpenApiReference
-                            {
-                                Id = "Bearer",
-                                Type = ReferenceType.SecurityScheme
-                            }
-                        },
-                        new List<string>()
-                    }
-                });
-            }
-        }
-
-        private static SwaggerSettings? GetSwaggerSettings(IConfiguration configuration)
-        {
-            IConfigurationSection configurationSection = configuration.GetSection(SwaggerDocumentationSectionName);
-            return configurationSection.Exists() ? configurationSection.Get<SwaggerSettings>() : null;
-        }
-
-        private static OpenApiInfo? MapSwaggerSettingsToOpenApiInfo(SwaggerSettings? settings)
-        {
-            if (settings is null)
-            {
-                return null;
-            }
-            OpenApiInfo info = new()
-            {
-                Title = settings.Title,
-                Description = settings.Description,
-                Version = settings.Version
-            };
-            if (settings.Contact is not null)
-            {
-                info.Contact = new()
-                {
-                    Name = settings.Contact.Name,
-                    Url = settings.Contact.Url is not null ? new Uri(settings.Contact.Url) : null,
-                    Email = settings.Contact.Email
-                };
-            }
-            if (settings.License is not null)
-            {
-                info.License = new()
-                {
-                    Name = settings.License.Name,
-                    Url = settings.License.Url is not null ? new Uri(settings.License.Url) : null
-                };
-            }
-            return info;
-        }
 
         /// <summary>
         /// Adds Swagger documentation generator middleware.
@@ -171,11 +98,89 @@ namespace Kros.Swagger.Extensions
                 if (settings is not null)
                 {
                     c.SwaggerEndpoint($"{settings.Version}/swagger.json", settings.Title);
+                    c.OAuthClientId(settings.OAuthClientId);
+                    c.OAuthClientSecret(settings.OAuthClientSecret);
+                    c.OAuthScopes(GetAllOAuthScopes(settings.Authorizations.Values));
+                    c.OAuthUsePkce();
                 }
                 setupUiAction?.Invoke(c);
             });
 
             return app;
+        }
+
+        private static SwaggerSettings? GetSwaggerSettings(IConfiguration configuration)
+        {
+            IConfigurationSection configurationSection = configuration.GetSection(SwaggerDocumentationSectionName);
+            return configurationSection.Exists() ? configurationSection.Get<SwaggerSettings>() : null;
+        }
+
+        private static void AddAuthorization(SwaggerGenOptions swaggerOptions, SwaggerSettings settings)
+        {
+            foreach (KeyValuePair<string, OpenApiSecurityScheme> auth in settings.Authorizations)
+            {
+                string name = auth.Key;
+                OpenApiSecurityScheme scheme = auth.Value;
+
+                swaggerOptions.AddSecurityDefinition(name, scheme);
+
+                /// From OpenApiSecurityRequirement documentation:
+                /// If the security scheme is of type "oauth2" or "openIdConnect",
+                /// then the scopes value is a list of scope names required for the execution.
+                /// For other security scheme types, the array MUST be empty
+                List<string> scopes = [];
+                if (((scheme.Type == SecuritySchemeType.OAuth2) || (scheme.Type == SecuritySchemeType.OpenIdConnect))
+                    && (scheme.Flows is not null))
+                {
+                    GetScopes(scopes, scheme);
+                    scopes = scopes.Distinct(StringComparer.Ordinal).ToList();
+                }
+                swaggerOptions.AddSecurityRequirement(new OpenApiSecurityRequirement()
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.SecurityScheme,
+                                Id = name,
+                            }
+                        },
+                        scopes
+                    }
+                });
+            }
+        }
+
+        private static string[] GetAllOAuthScopes(IEnumerable<OpenApiSecurityScheme> schemes)
+        {
+            List<string> allScopes = [];
+            foreach (OpenApiSecurityScheme scheme in schemes)
+            {
+                GetScopes(allScopes, scheme);
+            }
+            return allScopes.Distinct(StringComparer.Ordinal).ToArray();
+        }
+
+        private static void GetScopes(List<string> scopes, OpenApiSecurityScheme scheme)
+        {
+            static void AddFlowScopes(List<string> scopes, OpenApiOAuthFlow? flow)
+            {
+                IEnumerable<string>? flowScopes = flow?.Scopes?.Keys;
+                if (flowScopes is not null)
+                {
+                    scopes.AddRange(flowScopes);
+                }
+            }
+
+            if (((scheme.Type == SecuritySchemeType.OAuth2) || (scheme.Type == SecuritySchemeType.OpenIdConnect))
+                && (scheme.Flows is not null))
+            {
+                AddFlowScopes(scopes, scheme.Flows.Implicit);
+                AddFlowScopes(scopes, scheme.Flows.Password);
+                AddFlowScopes(scopes, scheme.Flows.ClientCredentials);
+                AddFlowScopes(scopes, scheme.Flows.AuthorizationCode);
+            }
         }
     }
 }

--- a/src/Kros.Swagger.Extensions/SwaggerGenOptionsExtensions.cs
+++ b/src/Kros.Swagger.Extensions/SwaggerGenOptionsExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Kros.Swagger.Extensions.Filters;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -13,6 +14,34 @@ namespace Kros.Swagger.Extensions
     /// </summary>
     public static class SwaggerGenOptionsExtensions
     {
+        /// <summary>
+        /// Add operation filter for allowing anonymous access to operations.
+        /// This filter is suitable, if by default all your endpoints are authorized and you want just for some of them
+        /// to allow anonymous access. It clears any security requirements from operation if the operation
+        /// has <see cref="AllowAnonymousAttribute"/> and sets security requirements for all other operations.
+        /// </summary>
+        /// <param name="opt">Swagger generator options.</param>
+        /// <returns>Input <paramref name="opt"/> value for fluent chaining.</returns>
+        public static SwaggerGenOptions ClearSecurityRequirementsFromAnonymousEndpoints(this SwaggerGenOptions opt)
+        {
+            opt.OperationFilter<AllowAnonymousOperationFilter>();
+            return opt;
+        }
+
+        /// <summary>
+        /// Add operation filter for allowing authorized access to operations.
+        /// This filter is suitable, if by default all your endpoints allow anonymous access and you want just for some of them
+        /// to be authorized. It sets security requirements for all operations which have <see cref="AuthorizeAttribute"/>
+        /// and clears any security requirements from all other operations.
+        /// </summary>
+        /// <param name="opt">Swagger generator options.</param>
+        /// <returns>Input <paramref name="opt"/> value for fluent chaining.</returns>
+        public static SwaggerGenOptions SetSecurityRequirementsToAuthorizedEndpoints(this SwaggerGenOptions opt)
+        {
+            opt.OperationFilter<AuthorizeOperationFilter>();
+            return opt;
+        }
+
         /// <summary>
         /// Sets correct <c>nullable</c> flag in schema for nullable reference types.
         /// </summary>

--- a/src/Kros.Swagger.Extensions/SwaggerSettings.cs
+++ b/src/Kros.Swagger.Extensions/SwaggerSettings.cs
@@ -1,0 +1,82 @@
+﻿using System;
+
+namespace Kros.Swagger.Extensions
+{
+    /// <summary>
+    /// Settings for Swagger documentation.
+    /// </summary>
+    public class SwaggerSettings
+    {
+        #region Nested types
+
+        /// <summary>
+        /// API contact settings.
+        /// </summary>
+        public class ContactSettings
+        {
+            /// <summary>
+            /// The identifying name of the contact person/organization.
+            /// </summary>
+            public string Name { get; set; } = string.Empty;
+
+            /// <summary>
+            /// The URL pointing to the contact information. MUST be in the format of a URL.
+            /// </summary>
+            public string Url { get; set; } = string.Empty;
+
+            /// <summary>
+            /// The email address of the contact person/organization.
+            /// MUST be in the format of an email address.
+            /// </summary>
+            public string Email { get; set; } = string.Empty;
+        }
+
+        /// <summary>
+        /// API license settings.
+        /// </summary>
+        public class LicenseSettings
+        {
+            /// <summary>
+            /// REQUIRED. The license name used for the API.
+            /// </summary>
+            public string Name { get; set; } = string.Empty;
+
+            /// <summary>
+            /// The URL pointing to the contact information. MUST be in the format of a URL.
+            /// </summary>
+            public string Url { get; set; } = string.Empty;
+        }
+
+        #endregion Nested types
+
+        /// <summary>
+        /// The title of the application.
+        /// </summary>
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>
+        /// A short description of the application.
+        /// </summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>
+        /// REQUIRED. The version of the OpenAPI document.
+        /// </summary>
+        public string Version { get; set; } = string.Empty;
+
+        /// <summary>
+        /// A URL to the Terms of Service for the API. MUST be in the format of a URL.
+        /// </summary>
+        public string TermsOfService { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The contact information for the exposed API.
+        /// </summary>
+        public ContactSettings Contact { get; } = new ContactSettings();
+
+        /// <summary>
+        /// The license information for the exposed API.
+        /// </summary>
+        public LicenseSettings License { get; } = new LicenseSettings();
+    }
+}

--- a/src/Kros.Swagger.Extensions/SwaggerSettings.cs
+++ b/src/Kros.Swagger.Extensions/SwaggerSettings.cs
@@ -1,82 +1,32 @@
-﻿using System;
+﻿using Microsoft.OpenApi.Models;
+using System.Collections.Generic;
 
 namespace Kros.Swagger.Extensions
 {
     /// <summary>
     /// Settings for Swagger documentation.
     /// </summary>
-    public class SwaggerSettings
+    public class SwaggerSettings : OpenApiInfo
     {
-        #region Nested types
+        /// <summary>
+        /// OAuth client ID.
+        /// </summary>
+        public string OAuthClientId { get; set; } = string.Empty;
 
         /// <summary>
-        /// API contact settings.
+        /// OAuth client secret.
         /// </summary>
-        public class ContactSettings
-        {
-            /// <summary>
-            /// The identifying name of the contact person/organization.
-            /// </summary>
-            public string Name { get; set; } = string.Empty;
-
-            /// <summary>
-            /// The URL pointing to the contact information. MUST be in the format of a URL.
-            /// </summary>
-            public string Url { get; set; } = string.Empty;
-
-            /// <summary>
-            /// The email address of the contact person/organization.
-            /// MUST be in the format of an email address.
-            /// </summary>
-            public string Email { get; set; } = string.Empty;
-        }
+        public string OAuthClientSecret { get; set; } = string.Empty;
 
         /// <summary>
-        /// API license settings.
+        /// OAuth scopes. There is usually no need to set this property.
+        /// If the property is empty, all scopes from OAuth security schemes are automatically added.
         /// </summary>
-        public class LicenseSettings
-        {
-            /// <summary>
-            /// REQUIRED. The license name used for the API.
-            /// </summary>
-            public string Name { get; set; } = string.Empty;
-
-            /// <summary>
-            /// The URL pointing to the contact information. MUST be in the format of a URL.
-            /// </summary>
-            public string Url { get; set; } = string.Empty;
-        }
-
-        #endregion Nested types
+        public List<string> OAuthScopes { get; } = [];
 
         /// <summary>
-        /// The title of the application.
+        /// Authorization security schemes.
         /// </summary>
-        public string Title { get; set; } = string.Empty;
-
-        /// <summary>
-        /// A short description of the application.
-        /// </summary>
-        public string Description { get; set; } = string.Empty;
-
-        /// <summary>
-        /// REQUIRED. The version of the OpenAPI document.
-        /// </summary>
-        public string Version { get; set; } = string.Empty;
-
-        /// <summary>
-        /// A URL to the Terms of Service for the API. MUST be in the format of a URL.
-        /// </summary>
-        public string TermsOfService { get; set; } = string.Empty;
-
-        /// <summary>
-        /// The contact information for the exposed API.
-        /// </summary>
-        public ContactSettings Contact { get; } = new ContactSettings();
-
-        /// <summary>
-        /// The license information for the exposed API.
-        /// </summary>
-        public LicenseSettings License { get; } = new LicenseSettings();
+        public Dictionary<string, OpenApiSecurityScheme> Authorizations { get; } = [];
     }
 }


### PR DESCRIPTION
- `SwaggerDocumentation` section is no longer required in configuration (`appsettings.json`).
- New class `SwaggerSettings` for settings is created. It inherits `OpenApiInfo`, so everything what worked before still works. It just introduces new properties to properly setup authorization.
- If client sets up authorization in configuration, it must also add some operation filter, which will add security requirement for operations which will use authorization.
  - No global operation filter is setup. Until now, there was global operation filter added and so all operations (even anonymous) were using authorization.
  - there are 2 operation filters defined, which can be used in when configuring client:
    - `ClearSecurityRequirementsFromAnonymousEndpoints`: this is suitable for APIs, where by default all endpoints are authorized and the anonymous ones are marked with `AllowAnonymous` attribute.
    - `SetSecurityRequirementsToAuthorizedEndpoints`: this is suitable for APIs, where by default all endpoints are anonymous and the authorized ones are marked with `Authorize` attribute.