### PR TITLE
Fix UserId telemetry

### DIFF
--- a/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
+++ b/src/Kros.ApplicationInsights.Extensions/Kros.ApplicationInsights.Extensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <Description>Extensions to facilitate work with Application Insights.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Kros.ApplicationInsights.Extensions/UserIdFromUserAgentInitializer.cs
+++ b/src/Kros.ApplicationInsights.Extensions/UserIdFromUserAgentInitializer.cs
@@ -2,10 +2,7 @@
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 [assembly: InternalsVisibleTo("Kros.ApplicationInsights.Extensions.Tests")]
 namespace Kros.ApplicationInsights.Extensions
@@ -33,7 +30,7 @@ namespace Kros.ApplicationInsights.Extensions
         public void Initialize(ITelemetry telemetry)
         {
             if (telemetry is RequestTelemetry requestTelemetry
-                && _httpContextAccessor.HttpContext.Request.Headers.ContainsKey("User-Agent"))
+                && _httpContextAccessor?.HttpContext.Request.Headers.ContainsKey("User-Agent") == true)
             {
                 requestTelemetry.Context.User.Id = _httpContextAccessor.HttpContext.Request.Headers["User-Agent"];
             }


### PR DESCRIPTION
Handled cases where the HTTP context accessor might be missing, ensuring the user ID is set only when the User-Agent header is available, such as when logging a Service Bus message.