### PR TITLE
Multiple API keys in API key auth

### DIFF
--- a/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationHandler.cs
+++ b/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationHandler.cs
@@ -8,51 +8,40 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 
-namespace Kros.AspNetCore.Authentication
+namespace Kros.AspNetCore.Authentication;
+
+/// <summary>
+/// Processes API key authentication using the request Basic auth header.
+/// </summary>
+public class ApiKeyBasicAuthenticationHandler(
+    IOptionsMonitor<ApiKeyBasicAuthenticationOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder) : AuthenticationHandler<ApiKeyBasicAuthenticationOptions>(options, logger, encoder)
 {
-    /// <summary>
-    /// Processes API key authentication using the request Basic auth header.
-    /// </summary>
-    public class ApiKeyBasicAuthenticationHandler : AuthenticationHandler<ApiKeyBasicAuthenticationOptions>
+    private readonly string _apiKeyHeaderName = HeaderNames.Authorization;
+    private const string ApiKeyPrefix = "Basic ";
+    private const string ApiKeyRole = "ApiKeyUser";
+
+    /// <inheritdoc/>
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        private readonly string _apiKeyHeaderName = HeaderNames.Authorization;
-        private const string ApiKeyPrefix = "Basic ";
-        private const string ApiKeyRole = "ApiKeyUser";
-
-        /// <summary>
-        /// Ctor.
-        /// </summary>
-        public ApiKeyBasicAuthenticationHandler(
-            IOptionsMonitor<ApiKeyBasicAuthenticationOptions> options,
-            ILoggerFactory logger,
-            UrlEncoder encoder) : base(options, logger, encoder)
+        if (!Request.Headers.TryGetValue(_apiKeyHeaderName, out StringValues headerApiKeyvalues)
+            || headerApiKeyvalues.Count == 0
+            || string.IsNullOrEmpty(headerApiKeyvalues[0])
+            || !headerApiKeyvalues[0].StartsWith(ApiKeyPrefix))
         {
+            return Task.FromResult(AuthenticateResult.NoResult());
         }
 
-        /// <inheritdoc/>
-        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        if (headerApiKeyvalues[0] == $"{ApiKeyPrefix}{Options.ApiKey}")
         {
-            if (!Request.Headers.TryGetValue(_apiKeyHeaderName, out StringValues headerApiKeyvalues)
-                || headerApiKeyvalues.Count == 0
-                || string.IsNullOrEmpty(headerApiKeyvalues[0])
-                || !headerApiKeyvalues[0].StartsWith(ApiKeyPrefix))
-            {
-                return Task.FromResult(AuthenticateResult.NoResult());
-            }
+            List<Claim> claims = [new Claim(ClaimTypes.Role, ApiKeyRole)];
+            ClaimsIdentity identity = new(claims, Options.Scheme);
+            AuthenticationTicket ticket = new(new ClaimsPrincipal(identity), Options.Scheme);
 
-            if (headerApiKeyvalues[0] == $"{ApiKeyPrefix}{Options.ApiKey}")
-            {
-                List<Claim> claims = new()
-                {
-                    new Claim(ClaimTypes.Role, ApiKeyRole)
-                };
-                ClaimsIdentity identity = new(claims, Options.Scheme);
-                AuthenticationTicket ticket = new(new ClaimsPrincipal(identity), Options.Scheme);
-
-                return Task.FromResult(AuthenticateResult.Success(ticket));
-            }
-
-            return Task.FromResult(AuthenticateResult.Fail("Wrong API key"));
+            return Task.FromResult(AuthenticateResult.Success(ticket));
         }
+
+        return Task.FromResult(AuthenticateResult.Fail($"Wrong API key for scheme: {Options.Scheme}"));
     }
 }

--- a/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationHandler.cs
+++ b/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationHandler.cs
@@ -14,9 +14,9 @@ namespace Kros.AspNetCore.Authentication;
 /// Processes API key authentication using the request Basic auth header.
 /// </summary>
 public class ApiKeyBasicAuthenticationHandler(
-    IOptionsMonitor<ApiKeyBasicAuthenticationOptions> options,
+    IOptionsMonitor<ApiKeyBasicAuthenticationScheme> options,
     ILoggerFactory logger,
-    UrlEncoder encoder) : AuthenticationHandler<ApiKeyBasicAuthenticationOptions>(options, logger, encoder)
+    UrlEncoder encoder) : AuthenticationHandler<ApiKeyBasicAuthenticationScheme>(options, logger, encoder)
 {
     private readonly string _apiKeyHeaderName = HeaderNames.Authorization;
     private const string ApiKeyPrefix = "Basic ";
@@ -36,12 +36,12 @@ public class ApiKeyBasicAuthenticationHandler(
         if (headerApiKeyvalues[0] == $"{ApiKeyPrefix}{Options.ApiKey}")
         {
             List<Claim> claims = [new Claim(ClaimTypes.Role, ApiKeyRole)];
-            ClaimsIdentity identity = new(claims, Options.Scheme);
-            AuthenticationTicket ticket = new(new ClaimsPrincipal(identity), Options.Scheme);
+            ClaimsIdentity identity = new(claims, Options.SchemeName);
+            AuthenticationTicket ticket = new(new ClaimsPrincipal(identity), Options.SchemeName);
 
             return Task.FromResult(AuthenticateResult.Success(ticket));
         }
 
-        return Task.FromResult(AuthenticateResult.Fail($"Wrong API key for scheme: {Options.Scheme}"));
+        return Task.FromResult(AuthenticateResult.Fail($"Wrong API key for scheme: {Options.SchemeName}"));
     }
 }

--- a/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationOptions.cs
+++ b/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationOptions.cs
@@ -3,18 +3,18 @@ using System.Collections.Generic;
 
 namespace Kros.AspNetCore.Authentication;
 
-/// <summary> 
-/// Options to configure the ApiKeyBasicAuthenticationHandler. 
-/// </summary> 
+/// <summary>
+/// Options to configure the ApiKeyBasicAuthenticationHandler.
+/// </summary>
 public class ApiKeyBasicAuthenticationOptions
 {
-    /// <summary> 
+    /// <summary>
     /// The API key, that will be checked during authentication (single scheme mode).
     /// </summary>
     [Obsolete("Use the Schemes property instead. This property will be removed in a future version.")]
     public string ApiKey { get; set; }
 
-    /// <summary> 
+    /// <summary>
     /// Auth scheme name (single scheme mode).
     /// </summary>
     [Obsolete("Use the Schemes property instead. This property will be removed in a future version.")]

--- a/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationOptions.cs
+++ b/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationOptions.cs
@@ -1,20 +1,56 @@
 ﻿using Microsoft.AspNetCore.Authentication;
+using System;
+using System.Collections.Generic;
 
-namespace Kros.AspNetCore.Authentication
+namespace Kros.AspNetCore.Authentication;
+
+/// <summary> 
+/// Options to configure the ApiKeyBasicAuthenticationHandler. 
+/// </summary> 
+public class ApiKeyBasicAuthenticationOptions : AuthenticationSchemeOptions
 {
-    /// <summary>
-    /// Options to configure the ApiKeyBasicAuthenticationHandler.
-    /// </summary>
-    public class ApiKeyBasicAuthenticationOptions : AuthenticationSchemeOptions
-    {
-        /// <summary>
-        /// The API key, that will be checked during authentication.
-        /// </summary>
-        public string ApiKey { get; set; }
+    /// <summary> 
+    /// The API key, that will be checked during authentication (single scheme mode).
+    /// </summary> 
+    public string ApiKey { get; set; }
 
-        /// <summary>
-        /// Auth scheme name.
-        /// </summary>
-        public string Scheme { get; set; }
+    /// <summary> 
+    /// Auth scheme name (single scheme mode).
+    /// </summary> 
+    public string Scheme { get; set; }
+
+    /// <summary>
+    /// Multiple authentication schemes with their respective API keys.
+    /// If specified, this takes precedence over the single Scheme/ApiKey properties.
+    /// Key: Scheme name, Value: API key.
+    /// </summary>
+    public Dictionary<string, string> Schemes { get; set; } = [];
+
+    /// <summary>
+    /// Retrieves the collection of authentication schemes and their associated keys. If specified, multiple schemes
+    /// take precedence over the single Scheme/ApiKey properties. Key: Scheme name, Value: API key.
+    /// </summary>
+    public IEnumerable<KeyValuePair<string, string>> GetSchemesWithApiKeys()
+    {
+        if (Schemes?.Count > 0)
+        {
+            return Schemes;
+        }
+        return [new KeyValuePair<string, string>(Scheme, ApiKey)];
+    }
+
+    /// <summary>
+    /// Gets the API key for a specific scheme.
+    /// </summary>
+    /// <param name="schemeName">The name of the scheme to get the API key for.</param>
+    /// <returns>The API key if found, otherwise null.</returns>
+    public string GetApiKeyForScheme(string schemeName)
+    {
+        if (Schemes?.Count > 0)
+        {
+            return Schemes.TryGetValue(schemeName, out string key) ? key : null;
+        }
+
+        return string.Equals(Scheme, schemeName, StringComparison.Ordinal) ? ApiKey : null;
     }
 }

--- a/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationOptions.cs
+++ b/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationOptions.cs
@@ -11,12 +11,14 @@ public class ApiKeyBasicAuthenticationOptions : AuthenticationSchemeOptions
 {
     /// <summary> 
     /// The API key, that will be checked during authentication (single scheme mode).
-    /// </summary> 
+    /// </summary>
+    [Obsolete("Use the Schemes property instead. This property will be removed in a future version.")]
     public string ApiKey { get; set; }
 
     /// <summary> 
     /// Auth scheme name (single scheme mode).
-    /// </summary> 
+    /// </summary>
+    [Obsolete("Use the Schemes property instead. This property will be removed in a future version.")]
     public string Scheme { get; set; }
 
     /// <summary>
@@ -25,32 +27,4 @@ public class ApiKeyBasicAuthenticationOptions : AuthenticationSchemeOptions
     /// Key: Scheme name, Value: API key.
     /// </summary>
     public Dictionary<string, string> Schemes { get; set; } = [];
-
-    /// <summary>
-    /// Retrieves the collection of authentication schemes and their associated keys. If specified, multiple schemes
-    /// take precedence over the single Scheme/ApiKey properties. Key: Scheme name, Value: API key.
-    /// </summary>
-    public IEnumerable<KeyValuePair<string, string>> GetSchemesWithApiKeys()
-    {
-        if (Schemes?.Count > 0)
-        {
-            return Schemes;
-        }
-        return [new KeyValuePair<string, string>(Scheme, ApiKey)];
-    }
-
-    /// <summary>
-    /// Gets the API key for a specific scheme.
-    /// </summary>
-    /// <param name="schemeName">The name of the scheme to get the API key for.</param>
-    /// <returns>The API key if found, otherwise null.</returns>
-    public string GetApiKeyForScheme(string schemeName)
-    {
-        if (Schemes?.Count > 0)
-        {
-            return Schemes.TryGetValue(schemeName, out string key) ? key : null;
-        }
-
-        return string.Equals(Scheme, schemeName, StringComparison.Ordinal) ? ApiKey : null;
-    }
 }

--- a/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationOptions.cs
+++ b/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationOptions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Authentication;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Kros.AspNetCore.Authentication;
@@ -7,7 +6,7 @@ namespace Kros.AspNetCore.Authentication;
 /// <summary> 
 /// Options to configure the ApiKeyBasicAuthenticationHandler. 
 /// </summary> 
-public class ApiKeyBasicAuthenticationOptions : AuthenticationSchemeOptions
+public class ApiKeyBasicAuthenticationOptions
 {
     /// <summary> 
     /// The API key, that will be checked during authentication (single scheme mode).

--- a/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationScheme.cs
+++ b/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationScheme.cs
@@ -7,12 +7,12 @@ namespace Kros.AspNetCore.Authentication;
 /// </summary>
 public class ApiKeyBasicAuthenticationScheme : AuthenticationSchemeOptions
 {
-    /// <summary> 
+    /// <summary>
     /// The API key, that will be checked during authentication.
     /// </summary>
     public string ApiKey { get; set; }
 
-    /// <summary> 
+    /// <summary>
     /// Auth scheme name (single scheme mode).
     /// </summary>
     public string SchemeName { get; set; }

--- a/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationScheme.cs
+++ b/src/Kros.AspNetCore/Authentication/ApiKeyBasicAuthenticationScheme.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Authentication;
+
+namespace Kros.AspNetCore.Authentication;
+
+/// <summary>
+/// Internally used settings for the API key authentication scheme.
+/// </summary>
+public class ApiKeyBasicAuthenticationScheme : AuthenticationSchemeOptions
+{
+    /// <summary> 
+    /// The API key, that will be checked during authentication.
+    /// </summary>
+    public string ApiKey { get; set; }
+
+    /// <summary> 
+    /// Auth scheme name (single scheme mode).
+    /// </summary>
+    public string SchemeName { get; set; }
+}

--- a/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
+++ b/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
@@ -112,11 +112,11 @@ public static class ServiceCollectionExtensions
             ?? throw new ArgumentNullException(nameof(configuration),
                 $"{Helpers.GetSectionName<ApiKeyBasicAuthenticationOptions>()} not found in configuration");
 
-        return builder.AddScheme<ApiKeyBasicAuthenticationOptions, ApiKeyBasicAuthenticationHandler>(configOptions.Scheme,
+        return builder.AddScheme<ApiKeyBasicAuthenticationScheme, ApiKeyBasicAuthenticationHandler>(configOptions.Scheme,
             options =>
             {
                 options.ApiKey = configOptions.ApiKey;
-                options.Scheme = configOptions.Scheme;
+                options.SchemeName = configOptions.Scheme;
             });
     }
 
@@ -146,10 +146,10 @@ public static class ServiceCollectionExtensions
 
         foreach (KeyValuePair<string, string> configScheme in configOptions.Schemes)
         {
-            builder.AddScheme<ApiKeyBasicAuthenticationOptions, ApiKeyBasicAuthenticationHandler>(configScheme.Key,
+            builder.AddScheme<ApiKeyBasicAuthenticationScheme, ApiKeyBasicAuthenticationHandler>(configScheme.Key,
                 options =>
                 {
-                    options.Scheme = configScheme.Key;
+                    options.SchemeName = configScheme.Key;
                     options.ApiKey = configScheme.Value;
                 });
         }

--- a/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
+++ b/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
@@ -103,7 +103,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="builder">Authentication builder.</param>
     /// <param name="configuration">Configuration.</param>
-    [Obsolete($"Use {nameof(AddApiKeyBasicAuthenticationSchemes)} instead with multiple schemes support.")]
+    [Obsolete($"Use {nameof(AddApiKeyBasicAuthenticationSchemes)} instead, with multiple schemes support.")]
     public static AuthenticationBuilder AddApiKeyBasicAuthentication(
         this AuthenticationBuilder builder,
         IConfiguration configuration)

--- a/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
+++ b/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
@@ -103,7 +103,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="builder">Authentication builder.</param>
     /// <param name="configuration">Configuration.</param>
-    [Obsolete($"Use {nameof(AddApiKeyBasicAuthenticationSchemes)} instead, with multiple schemes support.")]
+    [Obsolete($"Use {nameof(AddApiKeyBasicAuthenticationSchemes)} instead. You must also change configuration and DevOps secrets path as well!")]
     public static AuthenticationBuilder AddApiKeyBasicAuthentication(
         this AuthenticationBuilder builder,
         IConfiguration configuration)

--- a/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
+++ b/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
@@ -10,121 +10,124 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Text;
 
-namespace Kros.AspNetCore.Authorization
+namespace Kros.AspNetCore.Authorization;
+
+/// <summary>
+/// Authorization extensions for <see cref="IServiceCollection"/>.
+/// </summary>
+public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Authorization extensions for <see cref="IServiceCollection"/>.
+    /// Configure gateway authorization.
     /// </summary>
-    public static class ServiceCollectionExtensions
+    /// <param name="services">Collection of app services.</param>
+    public static IServiceCollection AddGatewayJwtAuthorization(this IServiceCollection services)
+        => services
+        .AddMemoryCache()
+        .AddHttpClient(GatewayAuthorizationMiddleware.AuthorizationHttpClientName)
+        .Services;
+
+    /// <summary>
+    /// Configure downstream api authentication.
+    /// </summary>
+    /// <param name="services">Collection of app services.</param>
+    /// <param name="scheme">Scheme name for authentication.</param>
+    /// <param name="configuration">Configuration from which the options are loaded.</param>
+    /// <param name="configureOptions">Configuration.</param>
+    public static AuthenticationBuilder AddApiJwtAuthentication(
+        this IServiceCollection services,
+        string scheme,
+        IConfiguration configuration,
+        Action<JwtBearerOptions> configureOptions = null)
     {
-        /// <summary>
-        /// Configure gateway authorization.
-        /// </summary>
-        /// <param name="services">Collection of app services.</param>
-        public static IServiceCollection AddGatewayJwtAuthorization(this IServiceCollection services)
-            => services
-            .AddMemoryCache()
-            .AddHttpClient(GatewayAuthorizationMiddleware.AuthorizationHttpClientName)
-            .Services;
+        return AddApiJwtAuthentication(services, new string[] { scheme }, configuration, configureOptions);
+    }
 
-        /// <summary>
-        /// Configure downstream api authentication.
-        /// </summary>
-        /// <param name="services">Collection of app services.</param>
-        /// <param name="scheme">Scheme name for authentication.</param>
-        /// <param name="configuration">Configuration from which the options are loaded.</param>
-        /// <param name="configureOptions">Configuration.</param>
-        public static AuthenticationBuilder AddApiJwtAuthentication(
-            this IServiceCollection services,
-            string scheme,
-            IConfiguration configuration,
-            Action<JwtBearerOptions> configureOptions = null)
+    /// <summary>
+    /// Configure downstream api authentication.
+    /// </summary>
+    /// <param name="services">Collection of app services.</param>
+    /// <param name="schemeNames">Scheme names for authentication.</param>
+    /// <param name="configuration">Configuration from which the options are loaded.</param>
+    /// <param name="configureOptions">Configuration.</param>
+    public static AuthenticationBuilder AddApiJwtAuthentication(
+        this IServiceCollection services,
+        IEnumerable<string> schemeNames,
+        IConfiguration configuration,
+        Action<JwtBearerOptions> configureOptions = null)
+    {
+        ApiJwtAuthorizationOptions configuredOptionsList = configuration.GetSection<ApiJwtAuthorizationOptions>();
+        IEnumerable<ApiJwtAuthorizationScheme> schemeList = (from scheme in configuredOptionsList.Schemes
+                                                             where schemeNames.Contains(scheme.SchemeName)
+                                                             select scheme);
+
+        if (!schemeList.Any())
         {
-            return AddApiJwtAuthentication(services, new string[] { scheme }, configuration, configureOptions);
+            throw new ArgumentException("No valid schemes for Api JWT authentication", nameof(schemeNames));
         }
 
-        /// <summary>
-        /// Configure downstream api authentication.
-        /// </summary>
-        /// <param name="services">Collection of app services.</param>
-        /// <param name="schemeNames">Scheme names for authentication.</param>
-        /// <param name="configuration">Configuration from which the options are loaded.</param>
-        /// <param name="configureOptions">Configuration.</param>
-        public static AuthenticationBuilder AddApiJwtAuthentication(
-            this IServiceCollection services,
-            IEnumerable<string> schemeNames,
-            IConfiguration configuration,
-            Action<JwtBearerOptions> configureOptions = null)
+        AuthenticationBuilder builder;
+
+        if (schemeList.Count() == 1)
         {
-            ApiJwtAuthorizationOptions configuredOptionsList = configuration.GetSection<ApiJwtAuthorizationOptions>();
-            IEnumerable<ApiJwtAuthorizationScheme> schemeList = (from scheme in configuredOptionsList.Schemes
-                                                                 where schemeNames.Contains(scheme.SchemeName)
-                                                                 select scheme);
+            builder = services.AddAuthentication(schemeList.First().SchemeName);
+        }
+        else
+        {
+            builder = services.AddAuthentication();
+        }
 
-            if (!schemeList.Any())
+        foreach (var scheme in schemeList)
+        {
+            builder = builder.AddJwtBearer(scheme.SchemeName, x =>
             {
-                throw new ArgumentException("No valid schemes for Api JWT authentication", nameof(schemeNames));
-            }
-
-            AuthenticationBuilder builder;
-
-            if (schemeList.Count() == 1)
-            {
-                builder = services.AddAuthentication(schemeList.First().SchemeName);
-            }
-            else
-            {
-                builder = services.AddAuthentication();
-            }
-
-            foreach (var scheme in schemeList)
-            {
-                builder = builder.AddJwtBearer(scheme.SchemeName, x =>
+                x.RequireHttpsMetadata = scheme.RequireHttpsMetadata;
+                x.SaveToken = false;
+                x.TokenValidationParameters = new TokenValidationParameters
                 {
-                    x.RequireHttpsMetadata = scheme.RequireHttpsMetadata;
-                    x.SaveToken = false;
-                    x.TokenValidationParameters = new TokenValidationParameters
-                    {
-                        ValidateIssuerSigningKey = true,
-                        IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(scheme.JwtSecret)),
-                        ValidateIssuer = false,
-                        ValidateAudience = false
-                    };
+                    ValidateIssuerSigningKey = true,
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(scheme.JwtSecret)),
+                    ValidateIssuer = false,
+                    ValidateAudience = false
+                };
 
-                    configureOptions?.Invoke(x);
-                });
-            }
-
-            return builder;
+                configureOptions?.Invoke(x);
+            });
         }
 
-        /// <summary>
-        /// Configure API key Basic authentication.
-        /// </summary>
-        /// <param name="builder">Authentication builder.</param>
-        /// <param name="configuration">Configuration.</param>
-        public static AuthenticationBuilder AddApiKeyBasicAuthentication(
-            this AuthenticationBuilder builder,
-            IConfiguration configuration)
+        return builder;
+    }
+
+    /// <summary>
+    /// Configure API key Basic authentication.
+    /// </summary>
+    /// <param name="builder">Authentication builder.</param>
+    /// <param name="configuration">Configuration.</param>
+    public static AuthenticationBuilder AddApiKeyBasicAuthentication(
+        this AuthenticationBuilder builder,
+        IConfiguration configuration)
+    {
+        ApiKeyBasicAuthenticationOptions configOptions = configuration.GetSection<ApiKeyBasicAuthenticationOptions>()
+            ?? throw new ArgumentNullException(nameof(configuration),
+                $"{nameof(ApiKeyBasicAuthenticationOptions)} not found in configuration");
+
+        foreach (KeyValuePair<string, string> configScheme in configOptions.GetSchemesWithApiKeys())
         {
-            ApiKeyBasicAuthenticationOptions configOptions = configuration.GetSection<ApiKeyBasicAuthenticationOptions>();
-            if (configOptions == null)
-            {
-                throw new ArgumentNullException(nameof(configuration), $"{nameof(ApiKeyBasicAuthenticationOptions)} not found in configuration");
-            }
-            return builder.AddScheme<ApiKeyBasicAuthenticationOptions, ApiKeyBasicAuthenticationHandler>(configOptions.Scheme,
+            builder.AddScheme<ApiKeyBasicAuthenticationOptions, ApiKeyBasicAuthenticationHandler>(configScheme.Key,
                 options =>
                 {
-                    options.ApiKey = configOptions.ApiKey;
-                    options.Scheme = configOptions.Scheme;
+                    options.Scheme = configScheme.Key;
+                    options.ApiKey = configScheme.Value;
                 });
         }
 
-        /// <summary>
-        /// Adds jwt bearer claims middleware dependencies.
-        /// </summary>
-        /// <param name="services">The services.</param>
-        public static IServiceCollection AddJwtBearerClaims(this IServiceCollection services)
-            => services.AddSingleton<JwtSecurityTokenHandler>();
+        return builder;
     }
+
+    /// <summary>
+    /// Adds jwt bearer claims middleware dependencies.
+    /// </summary>
+    /// <param name="services">The services.</param>
+    public static IServiceCollection AddJwtBearerClaims(this IServiceCollection services)
+        => services.AddSingleton<JwtSecurityTokenHandler>();
 }

--- a/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
+++ b/src/Kros.AspNetCore/Authorization/ServiceCollectionExtensions.cs
@@ -103,15 +103,48 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="builder">Authentication builder.</param>
     /// <param name="configuration">Configuration.</param>
+    [Obsolete($"Use {nameof(AddApiKeyBasicAuthenticationSchemes)} instead with multiple schemes support.")]
     public static AuthenticationBuilder AddApiKeyBasicAuthentication(
         this AuthenticationBuilder builder,
         IConfiguration configuration)
     {
         ApiKeyBasicAuthenticationOptions configOptions = configuration.GetSection<ApiKeyBasicAuthenticationOptions>()
             ?? throw new ArgumentNullException(nameof(configuration),
-                $"{nameof(ApiKeyBasicAuthenticationOptions)} not found in configuration");
+                $"{Helpers.GetSectionName<ApiKeyBasicAuthenticationOptions>()} not found in configuration");
 
-        foreach (KeyValuePair<string, string> configScheme in configOptions.GetSchemesWithApiKeys())
+        return builder.AddScheme<ApiKeyBasicAuthenticationOptions, ApiKeyBasicAuthenticationHandler>(configOptions.Scheme,
+            options =>
+            {
+                options.ApiKey = configOptions.ApiKey;
+                options.Scheme = configOptions.Scheme;
+            });
+    }
+
+    /// <summary>
+    /// Configure API key Basic authentication with multiple schemes support.
+    /// </summary>
+    /// <param name="builder">Authentication builder.</param>
+    /// <param name="configuration">Configuration.</param>
+    /// <remarks>
+    /// Example configuration:
+    /// {
+    ///   "ApiKeyBasicAuthentication": {
+    ///     "Schemes": {
+    ///       "Basic.ApiKey": "key1",
+    ///       "Another.ApiKey": "key2"
+    ///     }
+    ///   }
+    /// }
+    /// </remarks>
+    public static AuthenticationBuilder AddApiKeyBasicAuthenticationSchemes(
+        this AuthenticationBuilder builder,
+        IConfiguration configuration)
+    {
+        ApiKeyBasicAuthenticationOptions configOptions = configuration.GetSection<ApiKeyBasicAuthenticationOptions>()
+            ?? throw new ArgumentNullException(nameof(configuration),
+                $"{Helpers.GetSectionName<ApiKeyBasicAuthenticationOptions>()} not found in configuration");
+
+        foreach (KeyValuePair<string, string> configScheme in configOptions.Schemes)
         {
             builder.AddScheme<ApiKeyBasicAuthenticationOptions, ApiKeyBasicAuthenticationHandler>(configScheme.Key,
                 options =>

--- a/src/Kros.AspNetCore/Kros.AspNetCore.csproj
+++ b/src/Kros.AspNetCore/Kros.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>4.1.4</Version>
+    <Version>4.1.5</Version>
     <Description>General utilities and helpers for building ASP.NET Core WEB API</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/tests/Kros.AspNetCore.Tests/Authentication/ApiKeyBasicAuthenticationHandlerShould.cs
+++ b/tests/Kros.AspNetCore.Tests/Authentication/ApiKeyBasicAuthenticationHandlerShould.cs
@@ -14,24 +14,24 @@ namespace Kros.AspNetCore.Tests.Authentication
 {
     public class ApiKeyBasicAuthenticationHandlerShould
     {
-        private readonly ApiKeyBasicAuthenticationOptions _options;
-        private readonly IOptionsMonitor<ApiKeyBasicAuthenticationOptions> _optionsMonitor;
+        private readonly ApiKeyBasicAuthenticationScheme _apiKeyAuthScheme;
+        private readonly IOptionsMonitor<ApiKeyBasicAuthenticationScheme> _apiKeyAuthSchemeMonitor;
         private readonly ILoggerFactory _loggerFactory;
         private readonly ApiKeyBasicAuthenticationHandler _handler;
 
         public ApiKeyBasicAuthenticationHandlerShould()
         {
-            _options = new ApiKeyBasicAuthenticationOptions()
+            _apiKeyAuthScheme = new ApiKeyBasicAuthenticationScheme()
             {
-                Scheme = "Basic.ApiKey",
+                SchemeName = "Basic.ApiKey",
                 ApiKey = "key2"
             };
-            _optionsMonitor = Substitute.For<IOptionsMonitor<ApiKeyBasicAuthenticationOptions>>();
-            _optionsMonitor.Get(_options.Scheme).Returns(_options);
+            _apiKeyAuthSchemeMonitor = Substitute.For<IOptionsMonitor<ApiKeyBasicAuthenticationScheme>>();
+            _apiKeyAuthSchemeMonitor.Get(_apiKeyAuthScheme.SchemeName).Returns(_apiKeyAuthScheme);
             _loggerFactory = Substitute.For<ILoggerFactory>();
             _loggerFactory.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
             _handler = new ApiKeyBasicAuthenticationHandler(
-                _optionsMonitor,
+                _apiKeyAuthSchemeMonitor,
                 _loggerFactory,
                 Substitute.For<UrlEncoder>());
         }
@@ -41,7 +41,7 @@ namespace Kros.AspNetCore.Tests.Authentication
         {
             DefaultHttpContext context = new();
             await _handler.InitializeAsync(
-                new AuthenticationScheme(_options.Scheme, null, typeof(ApiKeyBasicAuthenticationHandler)),
+                new AuthenticationScheme(_apiKeyAuthScheme.SchemeName, null, typeof(ApiKeyBasicAuthenticationHandler)),
                 context);
             AuthenticateResult result = await _handler.AuthenticateAsync();
 
@@ -55,7 +55,7 @@ namespace Kros.AspNetCore.Tests.Authentication
             DefaultHttpContext context = new();
             context.Request.Headers[HeaderNames.Authorization] = "Bearer key2";
             await _handler.InitializeAsync(
-                new AuthenticationScheme(_options.Scheme, null, typeof(ApiKeyBasicAuthenticationHandler)),
+                new AuthenticationScheme(_apiKeyAuthScheme.SchemeName, null, typeof(ApiKeyBasicAuthenticationHandler)),
                 context);
             AuthenticateResult result = await _handler.AuthenticateAsync();
 
@@ -69,7 +69,7 @@ namespace Kros.AspNetCore.Tests.Authentication
             DefaultHttpContext context = new();
             context.Request.Headers[HeaderNames.Authorization] = "Basic wrong_key";
             await _handler.InitializeAsync(
-                new AuthenticationScheme(_options.Scheme, null, typeof(ApiKeyBasicAuthenticationHandler)),
+                new AuthenticationScheme(_apiKeyAuthScheme.SchemeName, null, typeof(ApiKeyBasicAuthenticationHandler)),
                 context);
             AuthenticateResult result = await _handler.AuthenticateAsync();
 
@@ -83,7 +83,7 @@ namespace Kros.AspNetCore.Tests.Authentication
             DefaultHttpContext context = new();
             context.Request.Headers[HeaderNames.Authorization] = "Basic key2";
             await _handler.InitializeAsync(
-                new AuthenticationScheme(_options.Scheme, null, typeof(ApiKeyBasicAuthenticationHandler)),
+                new AuthenticationScheme(_apiKeyAuthScheme.SchemeName, null, typeof(ApiKeyBasicAuthenticationHandler)),
                 context);
             AuthenticateResult result = await _handler.AuthenticateAsync();
 

--- a/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceCollectionExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceCollectionExtensionsShould.cs
@@ -83,7 +83,7 @@ namespace Kros.AspNetCore.ServiceDiscovery
         public async Task AddMultipleApiKeyBasicAuthenticationSchemes()
         {
             ServiceCollection serviceCollection = new();
-            serviceCollection.AddAuthentication().AddApiKeyBasicAuthentication(GetMultipleApiKeyConfiguration());
+            serviceCollection.AddAuthentication().AddApiKeyBasicAuthenticationSchemes(GetMultipleApiKeyConfiguration());
             IAuthenticationSchemeProvider schemeProvider = serviceCollection.BuildServiceProvider()
                 .GetRequiredService<IAuthenticationSchemeProvider>();
 
@@ -102,6 +102,8 @@ namespace Kros.AspNetCore.ServiceDiscovery
             ServiceCollection serviceCollection = new();
             IConfigurationRoot config = new ConfigurationBuilder().Build();
             serviceCollection.AddAuthentication().Invoking(builder => builder.AddApiKeyBasicAuthentication(config))
+                .Should().Throw<ArgumentNullException>();
+            serviceCollection.AddAuthentication().Invoking(builder => builder.AddApiKeyBasicAuthenticationSchemes(config))
                 .Should().Throw<ArgumentNullException>();
         }
 

--- a/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceCollectionExtensionsShould.cs
+++ b/tests/Kros.AspNetCore.Tests/ServiceDiscovery/ServiceCollectionExtensionsShould.cs
@@ -68,15 +68,32 @@ namespace Kros.AspNetCore.ServiceDiscovery
         }
 
         [Fact]
-        public async Task AddApiKeyBasicAuthentication()
+        public async Task AddSingleApiKeyBasicAuthentication()
         {
             ServiceCollection serviceCollection = new();
-            serviceCollection.AddAuthentication().AddApiKeyBasicAuthentication(GetApiKeyConfiguration());
+            serviceCollection.AddAuthentication().AddApiKeyBasicAuthentication(GetSingleApiKeyConfiguration());
             IAuthenticationSchemeProvider schemeProvider = serviceCollection.BuildServiceProvider()
                 .GetRequiredService<IAuthenticationSchemeProvider>();
             AuthenticationScheme scheme = await schemeProvider.GetSchemeAsync("Basic.ApiKey");
             scheme.Should().NotBeNull();
             scheme.HandlerType.Name.Should().Be(typeof(ApiKeyBasicAuthenticationHandler).Name);
+        }
+
+        [Fact]
+        public async Task AddMultipleApiKeyBasicAuthenticationSchemes()
+        {
+            ServiceCollection serviceCollection = new();
+            serviceCollection.AddAuthentication().AddApiKeyBasicAuthentication(GetMultipleApiKeyConfiguration());
+            IAuthenticationSchemeProvider schemeProvider = serviceCollection.BuildServiceProvider()
+                .GetRequiredService<IAuthenticationSchemeProvider>();
+
+            AuthenticationScheme scheme = await schemeProvider.GetSchemeAsync("Basic.ApiKey");
+            scheme.Should().NotBeNull();
+            scheme.HandlerType.Name.Should().Be(typeof(ApiKeyBasicAuthenticationHandler).Name);
+
+            AuthenticationScheme anotherScheme = await schemeProvider.GetSchemeAsync("Another.ApiKey");
+            anotherScheme.Should().NotBeNull();
+            anotherScheme.HandlerType.Name.Should().Be(typeof(ApiKeyBasicAuthenticationHandler).Name);
         }
 
         [Fact]
@@ -111,12 +128,28 @@ namespace Kros.AspNetCore.ServiceDiscovery
             return cfgBuilder.Build();
         }
 
-        private static IConfiguration GetApiKeyConfiguration()
+        private static IConfiguration GetSingleApiKeyConfiguration()
         {
             string cfg = @"{
                             ""ApiKeyBasicAuthentication"": {
                                 ""ApiKey"": ""key2"",
                                 ""Scheme"": ""Basic.ApiKey""
+                            }
+                        }";
+            ConfigurationBuilder cfgBuilder = new();
+            cfgBuilder.AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(cfg)));
+            return cfgBuilder.Build();
+        }
+
+        private static IConfiguration GetMultipleApiKeyConfiguration()
+        {
+            string cfg = @"{
+                            ""ApiKeyBasicAuthentication"": {
+                                ""Schemes"":
+                                    {
+                                        ""Basic.ApiKey"": ""key1"",
+                                        ""Another.ApiKey"": ""key2""
+                                    }
                             }
                         }";
             ConfigurationBuilder cfgBuilder = new();


### PR DESCRIPTION
In API key auth, only a single scheme with a single API key was supported. Now, multiple schemes are supported, each with its own API key. The configuration supports both the old way (single scheme + key) as well as the new way (dictionary of schemes to keys).
Old way (single scheme):
```
{
    "ApiKeyBasicAuthentication": {
        "Scheme": "Webhook.ApiKey",
        "ApiKey": ""
    },
}
```

Multiple schemes:
```
{
  "ApiKeyBasicAuthentication": {
    "Schemes": {
      "Webhook.ApiKey": "key1",
      "Another.ApiKey": "key2"
    }
  }
}
```