### PR TITLE
Upgrade MassTransit

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,8 @@
     <PackageVersion Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageVersion Include="Kros.AspNetCore" Version="4.1.3" />
     <PackageVersion Include="Kros.Utils" Version="3.0.2" />
-    <PackageVersion Include="MassTransit.AspNetCore" Version="7.3.1" />
-    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.5.0" />
+    <PackageVersion Include="MassTransit" Version="8.5.2" />
+    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.5.2" />
     <PackageVersion Include="MediatR" Version="12.5.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.6" />

--- a/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
+++ b/src/Kros.MassTransit.AzureServiceBus/Kros.MassTransit.AzureServiceBus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>3.0.5</Version>
+    <Version>4.0.0</Version>
     <Description>Simpler configuration of MassTransit library.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>


### PR DESCRIPTION
Update MassTransit configuration to support the Azure Service Bus emulator with the new connection string format.

The latest version of MassTransit used an older version of the Service Bus SDK, which did not support the new connection string format. Therefore it was necessary to upgrade the version of MassTransit, which had some breaking changes.

